### PR TITLE
fixed build error regarding ice

### DIFF
--- a/DeepLearningSuite/CMakeLists.txt
+++ b/DeepLearningSuite/CMakeLists.txt
@@ -38,6 +38,7 @@ FIND_PACKAGE(CUDA REQUIRED)
 FIND_PACKAGE(JdeRobot REQUIRED)
 
  include(Deps/glog/CMakeLists.txt)
+ include(Deps/ice/CMakeLists.txt)
 FIND_PACKAGE(Boost REQUIRED program_options filesystem)
 FIND_PACKAGE(Qt5Widgets REQUIRED)
 FIND_PACKAGE(Qt5Core REQUIRED)
@@ -60,30 +61,6 @@ FIND_PACKAGE(Qt5OpenGL REQUIRED)
 	 ${Qt5Svg_LIBRARIES}
 	 ${Qt5OpenGL_LIBRARIES}
 )
-
-
-
-
- #manual ICE
-FIND_PATH( Ice_INCLUDE_DIR NAMES Ice/Ice.h  PATHS ENV C++LIB ENV)
- 
-IF( Ice_INCLUDE_DIR )
-    FIND_LIBRARY( Ice_LIBRARY1 NAMES Ice PATHS ENV C++LIB ENV PATH PATH_SUFFIXES lib lib64 )
-    FIND_LIBRARY( Ice_LIBRARY2 NAMES IceUtil PATHS ENV C++LIB ENV PATH PATH_SUFFIXES lib lib64)
-    FIND_LIBRARY( Ice_LIBRARY3 NAMES IceStorm PATHS ENV C++LIB ENV PATH PATH_SUFFIXES lib lib64)
-    SET (Ice_LIBRARIES ${Ice_LIBRARY1} ${Ice_LIBRARY2} ${Ice_LIBRARY3})
-    IF( Ice_LIBRARIES )
-		MESSAGE ("-- Ice found at ${Ice_LIBRARIES}")
-		include_directories(${Ice_INCLUDE_DIR})
-		link_directories(${Ice_LIBRARIES})
-    ENDIF( Ice_LIBRARIES )
-ENDIF(Ice_INCLUDE_DIR)
-
-IF(NOT Ice_LIBRARIES)
-		MESSAGE ("*** Ice not found")
-ENDIF()
-
-
 
 
 #darknet

--- a/DeepLearningSuite/Deps/ice/CMake/FindZeroCIce.cmake
+++ b/DeepLearningSuite/Deps/ice/CMake/FindZeroCIce.cmake
@@ -1,0 +1,69 @@
+# Find the ZeroC ICE includes and libraries for every module (Ice, IceStorm, IceUtil, etc)
+
+#
+# ZeroCIce_INCLUDE_DIR - Where the includes are. If everything is all right, ZeroCIceXXXX_INCLUDE_DIR is always the same. You usually will use this.
+# ZeroCIce_LIBRARIES - List of *all* the libraries. You usually will not use this but only ZeroCIceUtil_LIBRARY or alike
+# ZerocCIce_FOUND - True if the core Ice was found
+# ZeroCIceCore_FOUND
+# ZeroCIceCore_INCLUDE_DIR
+# ZeroCIceCore_LIBRARY
+# ZeroCIceBox_FOUND
+# ZeroCIceBox_INCLUDE_DIR
+# ZeroCIceBox_LIBRARY
+# ZeroCIceGrid_FOUND
+# ZeroCIceGrid_INCLUDE_DIR
+# ZeroCIceGrid_LIBRARY
+# ZeroCIcePatch2_FOUND
+# ZeroCIcePatch2_INCLUDE_DIR
+# ZeroCIcePatch2_LIBRARY
+# ZeroCIceSSL_FOUND
+# ZeroCIceSSL_INCLUDE_DIR
+# ZeroCIceSSL_LIBRARY
+# ZeroCIceStorm_FOUND
+# ZeroCIceStorm_INCLUDE_DIR
+# ZeroCIceStorm_LIBRARY
+# ZeroCIceUtil_FOUND
+# ZeroCIceUtil_INCLUDE_DIR
+# ZeroCIceUtil_LIBRARY
+# ZeroCIceXML_FOUND
+# ZeroCIceXML_INCLUDE_DIR
+# ZeroCIceXML_LIBRARY
+# ZeroCIceExecutables_FOUND
+
+#
+# Copyright (c) 2007, Pau Garcia i Quiles, <pgquiles@elpauer.org>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+SET( ZeroCIceCore_FIND_QUIETLY TRUE )
+SET( ZeroCIceBox_FIND_QUIETLY TRUE )
+SET( ZeroCIceGrid_FIND_QUIETLY TRUE )
+SET( ZeroCIcePatch2_FIND_QUIETLY TRUE )
+SET( ZeroCIceSSL_FIND_QUIETLY TRUE )
+SET( ZeroCIceStorm_FIND_QUIETLY TRUE )
+SET( ZeroCIceUtil_FIND_QUIETLY TRUE )
+SET( ZeroCIceXML_FIND_QUIETLY TRUE )
+SET( ZeroCIceExecutables_FIND_QUIETLY TRUE )
+
+FIND_PACKAGE( ZeroCIceCore )
+FIND_PACKAGE( ZeroCIceBox )
+FIND_PACKAGE( ZeroCIceGrid )
+FIND_PACKAGE( ZeroCIcePatch2 )
+FIND_PACKAGE( ZeroCIceSSL )
+FIND_PACKAGE( ZeroCIceStorm )
+FIND_PACKAGE( ZeroCIceUtil )
+FIND_PACKAGE( ZeroCIceXML )
+FIND_PACKAGE( ZeroCIceExecutables )
+
+SET( ZeroCIce_INCLUDE_DIR ${ZeroCIceCore_INCLUDE_DIR} )
+SET( ZeroCIce_LIBRARIES ${ZeroCIceCore_LIBRARY} ${ZeroCIceBox_LIBRARY} ${ZeroCIceGrid_LIBRARY} ${ZeroCIcePatch2_LIBRARY} ${ZeroCIceSSL_LIBRARY} ${ZeroCIceStorm_LIBRARY} ${ZeroCIceUtil_LIBRARY} ${ZeroCIceXML_LIBRARY} )
+
+FOREACH( exec ${ICE_EXECUTABLES} )
+	IF(ZeroCIce_${exec}_FOUND)
+		LIST(APPEND ZeroCIce_EXECUTABLES ${ZeroCIce_${exec}_BIN} )
+	ENDIF(ZeroCIce_${exec}_FOUND)
+ENDFOREACH( exec ${ICE_EXECUTABLES} )
+
+SET( ZeroCIce_FOUND ${ZeroCIceCore_FOUND} )
+

--- a/DeepLearningSuite/Deps/ice/CMake/FindZeroCIceBox.cmake
+++ b/DeepLearningSuite/Deps/ice/CMake/FindZeroCIceBox.cmake
@@ -1,0 +1,25 @@
+# Find the ZeroC ICEBox includes and libraries
+
+#
+# ZeroCIceBox_INCLUDE_DIR
+# ZeroCIceBox_LIBRARIES
+# ZeroCIceBox_FOUND
+
+
+#
+# Copyright (c) 2007, Pau Garcia i Quiles, <pgquiles@elpauer.org>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+FIND_PATH( ZeroCIceBox_INCLUDE_DIR NAMES IceBox/IceBox.h PATHS ENV C++LIB ENV PATH PATH_SUFFIXES include Ice Ice/include )
+
+IF( ZeroCIceBox_INCLUDE_DIR )
+	FIND_LIBRARY( ZeroCIceBox_LIBRARY NAMES IceBox PATHS ENV C++LIB ENV PATH PATH_SUFFIXES Ice lib-release lib_release )
+
+	IF( ZeroCIceBox_LIBRARY )
+		SET( ZeroCIceBox_FOUND TRUE )
+	ENDIF( ZeroCIceBox_LIBRARY )
+
+
+ENDIF( ZeroCIceBox_INCLUDE_DIR )

--- a/DeepLearningSuite/Deps/ice/CMake/FindZeroCIceCore.cmake
+++ b/DeepLearningSuite/Deps/ice/CMake/FindZeroCIceCore.cmake
@@ -1,0 +1,25 @@
+# Find the ZeroC ICE essential includes and libraries
+
+#
+# ZeroCIceCore_INCLUDE_DIR
+# ZeroCIceCore_LIBRARIES
+# ZeroCIceCore_FOUND
+
+
+#
+# Copyright (c) 2007, Pau Garcia i Quiles, <pgquiles@elpauer.org>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+FIND_PATH( ZeroCIceCore_INCLUDE_DIR NAMES Ice/Ice.h PATHS ENV C++LIB ENV PATH PATH_SUFFIXES include Ice Ice/include )
+
+IF( ZeroCIceCore_INCLUDE_DIR )
+	FIND_LIBRARY( ZeroCIceCore_LIBRARY NAMES Ice PATHS ENV C++LIB ENV PATH PATH_SUFFIXES Ice lib-release lib_release )
+
+	IF( ZeroCIceCore_LIBRARY )
+		SET( ZeroCIceCore_FOUND TRUE )
+	ENDIF( ZeroCIceCore_LIBRARY )
+
+
+ENDIF( ZeroCIceCore_INCLUDE_DIR )

--- a/DeepLearningSuite/Deps/ice/CMake/FindZeroCIceExecutables.cmake
+++ b/DeepLearningSuite/Deps/ice/CMake/FindZeroCIceExecutables.cmake
@@ -1,0 +1,39 @@
+# Find the ZeroC ICE executables: 
+#
+# dumpdb, glacier2router, icebox, iceboxadmin, icecpp, icegridadmin, 
+# icegridnode, icegridregistry, icepatch2calc, icepatch2client, 
+# icepatch2server, icestormadmin, slice2cpp, slice2cs, slice2docbook, 
+# slice2freeze, slice2freezej, slice2html, slice2java, slice2py, 
+# slice2rb, slice2vb, transformdb
+#
+# Sets ZeroCIceExecutables_FOUND to TRUE only if *any* of the executables
+# in the ICE_EXECUTABLES were found, therefore you must also check 
+# if ZeroCIce_XXXXX_FOUND is true for the executable you want
+#
+# Defines a ZeroCIce_XXXXX_FOUND and ZeroCIce_XXXXX_BIN variable for each
+# executable in the ICE_EXECUTABLES list (the _BIN is the location of the 
+# executable)
+#
+# Defines a ZeroCIce_slice_ICES variable with the location of Plugin.ice, 
+# Logger.ice, etc
+#
+# Copyright (c) 2007, Pau Garcia i Quiles, <pgquiles@elpauer.org>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+SET( ICE_EXECUTABLES dumpdb glacier2router icebox iceboxadmin icecpp icegridadmin icegridnode icegridregistry icepatch2calc icepatch2client icepatch2server icestormadmin slice2cpp slice2cs slice2docbook slice2freeze slice2freezej slice2html slice2java slice2py slice2rb slice2vb transformdb )
+
+FOREACH( exec ${ICE_EXECUTABLES} )
+
+	FIND_PROGRAM( ZeroCIce_${exec}_BIN NAMES ${exec} PATHS ENV C++LIB ENV PATH PATH_SUFFIXES bin bin_release bin-release )
+	FIND_PATH( ZeroCIce_slice_ICES NAMES Ice/Plugin.ice PATHS /usr/share ENV C++LIB ENV PATH PATH_SUFFIXES slice Ice/slice )
+#	MESSAGE( "ZeroCIce_slice_ICES = ${ZeroCIce_slice_ICES}" )
+	
+	IF( ZeroCIce_${exec}_BIN )
+
+		SET( ZeroCIce_${exec}_FOUND TRUE)
+		SET( ZeroCIceExecutables_FOUND TRUE )
+	ENDIF()
+
+ENDFOREACH( exec )

--- a/DeepLearningSuite/Deps/ice/CMake/FindZeroCIceGrid.cmake
+++ b/DeepLearningSuite/Deps/ice/CMake/FindZeroCIceGrid.cmake
@@ -1,0 +1,25 @@
+# Find the ZeroC ICEGrid includes and libraries
+
+#
+# ZeroCIceGrid_INCLUDE_DIR
+# ZeroCIceGrid_LIBRARIES
+# ZerocCIceCore_FOUND
+
+
+#
+# Copyright (c) 2007, Pau Garcia i Quiles, <pgquiles@elpauer.org>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+FIND_PATH( ZeroCIceGrid_INCLUDE_DIR NAMES IceGrid/UserAccountMapper.h PATHS ENV C++LIB ENV PATH PATH_SUFFIXES include Ice Ice/include )
+
+IF( ZeroCIceGrid_INCLUDE_DIR )
+	FIND_LIBRARY( ZeroCIceGrid_LIBRARY NAMES IceGrid PATHS ENV C++LIB ENV PATH PATH_SUFFIXES Ice lib-release lib_release )
+
+	IF( ZeroCIceGrid_LIBRARY )
+		SET( ZeroCIceGrid_FOUND TRUE )
+	ENDIF( ZeroCIceGrid_LIBRARY )
+
+
+ENDIF( ZeroCIceGrid_INCLUDE_DIR )

--- a/DeepLearningSuite/Deps/ice/CMake/FindZeroCIcePatch2.cmake
+++ b/DeepLearningSuite/Deps/ice/CMake/FindZeroCIcePatch2.cmake
@@ -1,0 +1,25 @@
+# Find the ZeroC ICEPatch2 includes and libraries
+
+#
+# ZeroCIcePatch2_INCLUDE_DIR
+# ZeroCIcePatch2_LIBRARIES
+# ZerocCIceCore_FOUND
+
+
+#
+# Copyright (c) 2007, Pau Garcia i Quiles, <pgquiles@elpauer.org>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+FIND_PATH( ZeroCIcePatch2_INCLUDE_DIR NAMES IcePatch2/ClientUtil.h PATHS ENV C++LIB ENV PATH PATH_SUFFIXES include Ice Ice/include )
+
+IF( ZeroCIcePatch2_INCLUDE_DIR )
+	FIND_LIBRARY( ZeroCIcePatch2_LIBRARY NAMES IcePatch2 PATHS ENV C++LIB ENV PATH PATH_SUFFIXES Ice lib-release lib_release )
+
+	IF( ZeroCIcePatch2_LIBRARY )
+		SET( ZeroCIcePatch2_FOUND TRUE )
+	ENDIF( ZeroCIcePatch2_LIBRARY )
+
+
+ENDIF( ZeroCIcePatch2_INCLUDE_DIR )

--- a/DeepLearningSuite/Deps/ice/CMake/FindZeroCIceSSL.cmake
+++ b/DeepLearningSuite/Deps/ice/CMake/FindZeroCIceSSL.cmake
@@ -1,0 +1,25 @@
+# Find the ZeroC ICESSL includes and libraries
+
+#
+# ZeroCIceSSL_INCLUDE_DIR
+# ZeroCIceSSL_LIBRARIES
+# ZerocCIceCore_FOUND
+
+
+#
+# Copyright (c) 2007, Pau Garcia i Quiles, <pgquiles@elpauer.org>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+FIND_PATH( ZeroCIceSSL_INCLUDE_DIR NAMES IceSSL/Plugin.h PATHS ENV C++LIB ENV PATH PATH_SUFFIXES include Ice Ice/include )
+
+IF( ZeroCIceSSL_INCLUDE_DIR )
+	FIND_LIBRARY( ZeroCIceSSL_LIBRARY NAMES IceSSL PATHS ENV C++LIB ENV PATH PATH_SUFFIXES Ice lib-release lib_release )
+
+	IF( ZeroCIceSSL_LIBRARY )
+		SET( ZeroCIceSSL_FOUND TRUE )
+	ENDIF( ZeroCIceSSL_LIBRARY )
+
+
+ENDIF( ZeroCIceSSL_INCLUDE_DIR )

--- a/DeepLearningSuite/Deps/ice/CMake/FindZeroCIceStorm.cmake
+++ b/DeepLearningSuite/Deps/ice/CMake/FindZeroCIceStorm.cmake
@@ -1,0 +1,25 @@
+# Find the ZeroC ICEStorm includes and libraries
+
+#
+# ZeroCIceStorm_INCLUDE_DIR
+# ZeroCIceStorm_LIBRARIES
+# ZerocCIceStorm_FOUND
+
+
+#
+# Copyright (c) 2007, Pau Garcia i Quiles, <pgquiles@elpauer.org>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+FIND_PATH( ZeroCIceStorm_INCLUDE_DIR NAMES IceStorm/IceStorm.h PATHS ENV C++LIB ENV PATH PATH_SUFFIXES include Ice Ice/include )
+
+IF( ZeroCIceStorm_INCLUDE_DIR )
+	FIND_LIBRARY( ZeroCIceStorm_LIBRARY NAMES IceStorm PATHS ENV C++LIB ENV PATH PATH_SUFFIXES Ice lib-release lib_release )
+
+	IF( ZeroCIceStorm_LIBRARY )
+		SET( ZeroCIceStorm_FOUND TRUE )
+	ENDIF( ZeroCIceStorm_LIBRARY )
+
+
+ENDIF( ZeroCIceStorm_INCLUDE_DIR )

--- a/DeepLearningSuite/Deps/ice/CMake/FindZeroCIceUtil.cmake
+++ b/DeepLearningSuite/Deps/ice/CMake/FindZeroCIceUtil.cmake
@@ -1,0 +1,25 @@
+# Find the ZeroC ICEUtil includes and libraries
+
+#
+# ZeroCIceUtil_INCLUDE_DIR
+# ZeroCIceUtil_LIBRARIES
+# ZerocCIceCore_FOUND
+
+
+#
+# Copyright (c) 2007, Pau Garcia i Quiles, <pgquiles@elpauer.org>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+FIND_PATH( ZeroCIceUtil_INCLUDE_DIR NAMES IceUtil/IceUtil.h PATHS ENV C++LIB ENV PATH PATH_SUFFIXES include Ice Ice/include )
+
+IF( ZeroCIceUtil_INCLUDE_DIR )
+	FIND_LIBRARY( ZeroCIceUtil_LIBRARY NAMES IceUtil PATHS ENV C++LIB ENV PATH PATH_SUFFIXES Ice lib-release lib_release )
+
+	IF( ZeroCIceUtil_LIBRARY )
+		SET( ZeroCIceUtil_FOUND TRUE )
+	ENDIF( ZeroCIceUtil_LIBRARY )
+
+
+ENDIF( ZeroCIceUtil_INCLUDE_DIR )

--- a/DeepLearningSuite/Deps/ice/CMake/FindZeroCIceXML.cmake
+++ b/DeepLearningSuite/Deps/ice/CMake/FindZeroCIceXML.cmake
@@ -1,0 +1,25 @@
+# Find the ZeroC ICEXML includes and libraries
+
+#
+# ZeroCIceXML_INCLUDE_DIR
+# ZeroCIceXML_LIBRARIES
+# ZerocCIceCore_FOUND
+
+
+#
+# Copyright (c) 2007, Pau Garcia i Quiles, <pgquiles@elpauer.org>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+FIND_PATH( ZeroCIceXML_INCLUDE_DIR NAMES IceXML/Parser.h PATHS ENV C++LIB ENV PATH PATH_SUFFIXES include Ice Ice/include )
+
+IF( ZeroCIceXML_INCLUDE_DIR )
+	FIND_LIBRARY( ZeroCIceXML_LIBRARY NAMES IceXML PATHS ENV C++LIB ENV PATH PATH_SUFFIXES Ice lib-release lib_release )
+
+	IF( ZeroCIceXML_LIBRARY )
+		SET( ZeroCIceXML_FOUND TRUE )
+	ENDIF( ZeroCIceXML_LIBRARY )
+
+
+ENDIF( ZeroCIceXML_INCLUDE_DIR )

--- a/DeepLearningSuite/Deps/ice/CMake/FindZeroIceCore.cmake
+++ b/DeepLearningSuite/Deps/ice/CMake/FindZeroIceCore.cmake
@@ -1,0 +1,25 @@
+# Find the ZeroC ICE essential includes and libraries
+
+#
+# ZeroCIceCore_INCLUDE_DIR
+# ZeroCIceCore_LIBRARIES
+# ZeroCIceCore_FOUND
+
+
+#
+# Copyright (c) 2007, Pau Garcia i Quiles, <pgquiles@elpauer.org>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+FIND_PATH( ZeroCIceCore_INCLUDE_DIR NAMES Ice/Ice.h PATHS ENV C++LIB ENV PATH PATH_SUFFIXES include Ice Ice/include )
+
+IF( ZeroCIceCore_INCLUDE_DIR )
+	FIND_LIBRARY( ZeroCIceCore_LIBRARY NAMES Ice PATHS ENV C++LIB ENV PATH PATH_SUFFIXES Ice lib-release lib_release )
+
+	IF( ZeroCIceCore_LIBRARY )
+		SET( ZeroCIceCore_FOUND TRUE )
+	ENDIF( ZeroCIceCore_LIBRARY )
+
+
+ENDIF( ZeroCIceCore_INCLUDE_DIR )

--- a/DeepLearningSuite/Deps/ice/CMakeLists.txt
+++ b/DeepLearningSuite/Deps/ice/CMakeLists.txt
@@ -1,0 +1,38 @@
+SET(CMAKE_MODULE_PATH
+	${CMAKE_MODULE_PATH}
+	"${CMAKE_CURRENT_LIST_DIR}/CMake"
+)
+
+SET(slice_path /usr/share/slice)
+
+#ICE installs c++11 libraries in this directory and we don't indicate this, cmake uses c++98 files
+SET(CMAKE_PREFIX_PATH /usr/lib/x86_64-linux-gnu/c++11)
+FIND_PACKAGE(ZeroCIceUtil)
+FIND_PACKAGE(ZeroCIceStorm)
+FIND_PACKAGE(ZeroCIce)
+	IF( ZeroCIceStorm_LIBRARY )
+		IF( ZeroCIceUtil_LIBRARY )
+			MESSAGE("-- Found Ice")
+			include_directories(${ZeroCIceUtil_INCLUDE_DIR})
+			link_directories(${ZeroCIceUtil_LIBRARY})
+			include_directories(${ZeroCIceCore_INCLUDE_DIR})
+			link_directories(${ZeroCIceCore_LIBRARY})
+			include_directories(${ZeroCIceStorm_INCLUDE_DIR})
+			link_directories(${ZeroCIceStorm_LIBRARY})
+			include_directories(${ZeroCIce_INCLUDE_DIR})
+			link_directories(${ZeroCIce_LIBRARIES})
+
+			list(APPEND DEPS libzeroc-ice3.6 zeroc-ice-utils libzeroc-icestorm3.6)
+			list(APPEND DEPS_DEV zeroc-ice-slice libzeroc-ice-dev)
+			set(Ice_LIBRARIES ${ZeroCIce_LIBRARIES})
+
+		ENDIF( ZeroCIceUtil_LIBRARY )
+	ENDIF( ZeroCIceStorm_LIBRARY )
+
+IF(NOT  ZeroCIceStorm_LIBRARY )
+	MESSAGE(FATAL_ERROR "*** IceStorm not found")
+ENDIF()
+
+IF(NOT  ZeroCIceUtil_LIBRARY )
+	MESSAGE(FATAL_ERROR "*** IceUtil not found")
+ENDIF()


### PR DESCRIPTION
This pull request resolves #14 and also changes the Readme.md to include JdeRobot_DIR option in cmake so as to find ```JdeRobotConfig.cmake```.
Earlier, cmake wasn't looking in ```/usr/lib/x86_64-linux-gnu/c++11```, rather it was linking the libraries available in ```/usr/lib/x86_64-linux-gnu/``` which caused the error mentioned in #14.
So, I implemented a JdeRobot style search of Ice by adding it in dependencies which also improves error logging.