### PR TITLE
fixed segmentation fault on deployer process

### DIFF
--- a/DeepLearningSuite/DatasetEvaluationApp/SamplerGeneratorHandler/Deployer.cpp
+++ b/DeepLearningSuite/DatasetEvaluationApp/SamplerGeneratorHandler/Deployer.cpp
@@ -15,8 +15,18 @@ SampleGeneratorHandler::Deployer::process(QListView *deployImpList, QListView *w
                                           const std::string &weightsPath, const std::string &cfgPath,
                                           const std::string &inferencerNamesPath, const std::string &inputInfo) {
 
-    GenericLiveReaderPtr reader = SamplerGenerationHandler::createLiveReaderPtr( inferencerNamesList,
+    GenericLiveReaderPtr reader;
+
+    try {
+
+        reader = SamplerGenerationHandler::createLiveReaderPtr( inferencerNamesList,
                                                                                  deployImpList,inputInfo,inferencerNamesPath);
+
+     } catch(const std::invalid_argument& ex) {
+         LOG(WARNING)<< "Error Creating Generic Live Reader\nError Message: " << ex.what();
+         return;
+
+     }
 
     std::vector<std::string> weights;
     if (! Utils::getListViewContent(weightsList,weights,weightsPath+ "/")){

--- a/DeepLearningSuite/DatasetEvaluationApp/gui/Utils.cpp
+++ b/DeepLearningSuite/DatasetEvaluationApp/gui/Utils.cpp
@@ -7,6 +7,11 @@
 bool Utils::getListViewContent(const QListView *list, std::vector<std::string> &content, const std::string &prefix) {
     content.clear();
 
+		if (list->model() == 0) {
+			return false;
+		}
+
+
     QModelIndexList selectedList =list->selectionModel()->selectedIndexes();
     for (auto it = selectedList.begin(), end = selectedList.end(); it != end; ++it){
         content.push_back(prefix + it->data().toString().toStdString());

--- a/DeepLearningSuite/DeepLearningSuiteLib/DatasetConverters/liveReaders/VideoReader.cpp
+++ b/DeepLearningSuite/DeepLearningSuiteLib/DatasetConverters/liveReaders/VideoReader.cpp
@@ -6,6 +6,10 @@
 
 VideoReader::VideoReader(const std::string &videoPath) {
     this->cap =  new cv::VideoCapture(videoPath);
+
+    if(!cap->isOpened())  // check if we succeeded
+			 throw std::invalid_argument( "Couldn't open Video file!" );
+
     init=false;
 }
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,11 @@ For **Non-GPU** users (CPU build):
 ```
 cmake -DCMAKE_INSTALL_PREFIX=<DARKNET_DIR> -DUSE_GPU=OFF ..
 ```
-<br>
-```
-    make -j4
-    sudo make -j4 install
 
-```
+``` make -j4 ``` <br>
+``` sudo make -j4 install ```
+
+
 
 Change <DARKNET_DIR> to your custom installation path.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ DeepLearning Suite is a set of tool that simplify the evaluation of most common 
 The idea is to offer a generic infrastructure to evaluates object detection algorithms againts a dataset and compute most common statistics:
 * Intersecion Over Union
 * Precision
-* Recall 
+* Recall
 
 
 
@@ -21,38 +21,43 @@ The idea is to offer a generic infrastructure to evaluates object detection algo
 
 
 # Sample generation Tool
-Sample Generation Tool has been developed in order to simply the process of generation samples for datasets focused on object detection. The tools provides some features to reduce the time on labeling objects as rectangles. 
+Sample Generation Tool has been developed in order to simply the process of generation samples for datasets focused on object detection. The tools provides some features to reduce the time on labeling objects as rectangles.
 
 
 # Requirements
 
 ### CUDA
 ```
-  # NVIDIA_GPGKEY_SUM=d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5 && \
+   NVIDIA_GPGKEY_SUM=d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5 && \
      NVIDIA_GPGKEY_FPR=ae09fe4bbd223a84b2ccfce3f60f4b3d7fa2af80 && \
-     apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub && \
-     apt-key adv --export --no-emit-version -a $NVIDIA_GPGKEY_FPR | tail -n +5 > cudasign.pub && \
+    sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub && \
+    sudo apt-key adv --export --no-emit-version -a $NVIDIA_GPGKEY_FPR | tail -n +5 > cudasign.pub && \
      echo "$NVIDIA_GPGKEY_SUM  cudasign.pub" | sha256sum -c --strict - && rm cudasign.pub && \
-     echo "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64 /" > /etc/apt/sources.list.d/cuda.list && \
-     echo "deb http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list
- 
- # apt-get install -y cuda
+     sudo sh -c 'echo "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64 /" > /etc/apt/sources.list.d/cuda.list' && \
+     sudo sh -c 'echo "deb http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list'
+```
+
+Update and Install
+
+```
+sudo apt-get update
+sudo apt-get install -y cuda
 ```
 
 ### Common deps
 ```
- # apt-get install -y build-essential git cmake rapidjson-dev libboost-dev sudo
+ sudo apt-get install -y build-essential git cmake rapidjson-dev libboost-dev sudo
 ```
 
 ### Opencv
 ```
-    # apt-get install libopencv-dev 
+sudo apt-get install libopencv-dev
 ```
 
 ### JDEROBOT
 #### Deps
-``` 
-    # apt-get install -y libboost-filesystem-dev libboost-system-dev libboost-thread-dev libeigen3-dev libgoogle-glog-dev \
+```
+    sudo apt-get install -y libboost-filesystem-dev libboost-system-dev libboost-thread-dev libeigen3-dev libgoogle-glog-dev \
           libgsl-dev libgtkgl2.0-dev libgtkmm-2.4-dev libglademm-2.4-dev libgnomecanvas2-dev libgoocanvasmm-2.0-dev libgnomecanvasmm-2.6-dev \
           libgtkglextmm-x11-1.2-dev libyaml-cpp-dev icestorm zeroc-ice libxml++2.6-dev qt5-default libqt5svg5-dev libtinyxml-dev \
           catkin libssl-dev
@@ -60,9 +65,9 @@ Sample Generation Tool has been developed in order to simply the process of gene
 
 #### Jderobot ThirdParty libraries:
 ```
-    git clone https://github.com/JdeRobot/ThirdParty 
+    git clone https://github.com/JdeRobot/ThirdParty
     cd ThirdParty
-    cd qflightinstruments 
+    cd qflightinstruments
     qmake  qfi.pro
     make -j4
     make install
@@ -73,34 +78,47 @@ Sample Generation Tool has been developed in order to simply the process of gene
 
 ```
     git clone https://github.com/JdeRobot/JdeRobot
-    cd JdeRobot 
-    cmake . -DENABLE_ROS=OFF 
-    make -j4 
-    cmake . 
+    cd JdeRobot
+    cmake . -DENABLE_ROS=OFF
+    make -j4
+    cmake .
     sudo make install
 ```
 
 ### Darknet (jderobot fork)
+Darknet supports both GPU and CPU builds, and GPU build is enabled by default.
+If your Computer doesn't have a NVIDIA Graphics card, then it is necessary to turn of GPU build in cmake by passing ```-DUSE_GPU=OFF``` as an option in cmake.
+
 ```
-    git clone https://github.com/JdeRobot/darknet && \
-    cd darknet && \
-    cmake . -DCMAKE_INSTALL_PREFIX=<DARKNET_DIR> && \
-    make -j4 && \
-    sudo make -j4 install && \
-    cmake . && \
-    rm -rf * && \
-    cmake . -DCMAKE_INSTALL_PREFIX=$DARKNET_DIR && \
-    make -j4 && \
+    git clone https://github.com/JdeRobot/darknet
+    cd darknet
+    mkdir build && cd build
+
+```
+
+For **GPU** users:<br>
+```
+cmake -DCMAKE_INSTALL_PREFIX=<DARKNET_DIR> ..
+```
+For **Non-GPU** users (CPU build):
+```
+cmake -DCMAKE_INSTALL_PREFIX=<DARKNET_DIR> -DUSE_GPU=OFF ..
+```
+<br>
+```
+    make -j4
     sudo make -j4 install
+
 ```
+
 Change <DARKNET_DIR> to your custom installation path.
 
 # How to compile DL_DetectionSuite:
 Once you have all the deps installed just:
 ```
-    git clone https://github.com/JdeRobot/DeepLearningSuite 
-    cd DeepLearningSuite 
-    cd DeepLearningSuite/ 
+    git clone https://github.com/JdeRobot/DeepLearningSuite
+    cd DeepLearningSuite
+    cd DeepLearningSuite/
     cmake . -DDARKNET_PATH=<DARKNET_DIR>
 ```
 


### PR DESCRIPTION
If the ```  QListView *list ``` passed in ``` Utils::getListViewContent``` is empty, then a segmentation fault occurs due to the line  ```QModelIndexList selectedList =list->selectionModel()->selectedIndexes(); ```. 

For instance, while clicking on process if inferencer names are empty in deployer tab due to wrong path then the application crashes with a segmentation fault. A screenshot is attached below
![screenshot from 2018-03-07 23-56-26](https://user-images.githubusercontent.com/18044818/37111808-bb1bc51e-2266-11e8-811f-3a5359b27a76.png)

This request fixes it by return false before and then logging a warning as it is supposed to be.


**Update**
This pull request now also fixes more bugs as mentioned below:

1) This pull request now also checks if Video Path is correct and Video file is valid before processing and raises a warning if incorrect.
Earlier, this was indefinitely causing Invalid Frame error.


2) Darknet was configured by default to build for GPU support, even for Non-GPU users.
Added instructions to switch it off for CPU builds. This was earlier causing CUDA Runtime error

3) Updated README.md Nvidia installation instructions to add ```sudo sh -c``` before echo fixing permission denied error and apt update before installing to update repos.

Mentioning @chanfr for review.
Thanks!