### PR TITLE
PyPI release & Github release Workflow using Poetry

### DIFF
--- a/.github/workflows/pypi-tag.yml
+++ b/.github/workflows/pypi-tag.yml
@@ -3,7 +3,7 @@ name: Release workflow
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - pyproject.toml
 
@@ -21,9 +21,9 @@ jobs:
       - name: Check version change
         id: version_check
         run: |
-          git fetch origin main --depth=2
+          git fetch origin master --depth=2
 
-          PREV_VERSION=$(git show origin/main~1:pyproject.toml | grep '^version' | cut -d '"' -f2)
+          PREV_VERSION=$(git show origin/master~1:pyproject.toml | grep '^version' | cut -d '"' -f2)
           CURR_VERSION=$(grep '^version' pyproject.toml | cut -d '"' -f2)
 
           echo "Previous version: $PREV_VERSION"


### PR DESCRIPTION
**What this PR does**

- Adds a GitHub Actions workflow to automatically build and publish the package to PyPI using Poetry
- Triggers only when the package version is updated in pyproject.toml on the master branch
- Ensures releases are created only when the version actually changes
- Automatically:
  - Builds the package via Poetry
  - Publishes to PyPI
  - Creates a git tag (vX.Y.Z)
  - Creates a corresponding GitHub Release with autogenerated notes

**Implementation notes**
- The workflow compares the previous and current version field in pyproject.toml to determine whether a release should be triggered
- Uses Poetry for dependency installation, build, and publishing
- GitHub Release creation is handled automatically after a successful PyPI publish
