### PR TITLE
fix: remove duplicate path validation block in dataset_viewer

### DIFF
--- a/tabs/dataset_viewer.py
+++ b/tabs/dataset_viewer.py
@@ -37,9 +37,6 @@ def dataset_viewer_tab():
             st.warning("Dataset files not found. Check path and split.")
             return
 
-        if not os.path.isdir(img_dir) or not os.path.isfile(ann_file):
-            st.warning("Dataset files not found. Check path and split.")
-            return
     elif dataset_type == "yolo":
         dataset_config_file = st.session_state.get("dataset_config_file", None)
         img_dir = os.path.join(dataset_path, f"images/{split}")


### PR DESCRIPTION
Closes #387 

## Summary
Removes the duplicate path validation block in `tabs/dataset_viewer.py`.

The validation check for COCO dataset files appeared twice consecutively with identical conditions,

## Changes
Removed duplicate  `if not os.path.isdir(img_dir) or not os.path.isfile(ann_file)` block