### PR TITLE
corrected bug for not counts gts

### DIFF
--- a/perceptionmetrics/utils/detection_metrics.py
+++ b/perceptionmetrics/utils/detection_metrics.py
@@ -66,6 +66,10 @@ class DetectionMetricsFactory:
             (gt_boxes, gt_labels, pred_boxes, pred_labels, pred_scores)
         )
 
+        # Update ground truth counts
+        for g_label in gt_labels:
+            self.gt_counts[int(g_label)] += 1
+
         # Handle empty inputs
         if len(gt_boxes) == 0 and len(pred_boxes) == 0:
             return  # Nothing to process
@@ -89,9 +93,6 @@ class DetectionMetricsFactory:
         for label in matches:
             self.results[label].extend(matches[label])
 
-        # Update ground truth counts
-        for g_label in gt_labels:
-            self.gt_counts[int(g_label)] += 1
 
     def _match_predictions(
         self,


### PR DESCRIPTION
in `detection_metrics.py` ground truths are not counted if the `update()`function ends early with no predictions.

I moved counting ground truths:

```python
# Update ground truth counts
for g_label in gt_labels:
      self.gt_counts[int(g_label)] += 1
```

prior to all early returns.