### PR TITLE
fix: fn_count always 0 in get_overall_precision_recall_curve

### DIFF
--- a/perceptionmetrics/utils/detection_metrics.py
+++ b/perceptionmetrics/utils/detection_metrics.py
@@ -296,6 +296,8 @@ class DetectionMetricsFactory:
         if len(all_detections) == 0:
             return {"precision": [0.0], "recall": [0.0]}
 
+        fn_count = sum(1 for d in all_detections if d[1] == -1)
+        
         # Sort by score
         all_detections = sorted(
             [d for d in all_detections if d[0] is not None], key=lambda x: -x[0]
@@ -303,7 +305,6 @@ class DetectionMetricsFactory:
 
         tps = [d[1] == 1 for d in all_detections]
         fps = [d[1] == 0 for d in all_detections]
-        fn_count = sum(1 for d in all_detections if d[1] == -1)
 
         _, precision, recall = compute_ap(tps, fps, fn_count)
 


### PR DESCRIPTION
Closes #396 

The `fn_count` was computed after filtering out `None`-score entries, so it was always 0. This caused recall to be computed as TP/TP instead of TP/(TP+FN), inflating the PR curve and AUC-PR.

Fix: count FNs from the raw unfiltered list before the score filter is applied.