### PR TITLE
[Bug-fix] prevent eval() from crashing in the case of an image with no annotations

### DIFF
--- a/perceptionmetrics/models/torch_detection.py
+++ b/perceptionmetrics/models/torch_detection.py
@@ -213,6 +213,8 @@ class ImageDetectionTorchDataset(Dataset):
         boxes, category_indices = self.dataset.read_annotation(ann_path)
 
         # Convert boxes/labels to tensors
+        if len(boxes) == 0:
+            boxes = torch.zeros((0, 4), dtype=torch.float32)
         boxes = tv_tensors.BoundingBoxes(
             boxes, format="XYXY", canvas_size=(image.height, image.width)
         )


### PR DESCRIPTION
This simple PR fixes #404 
In perceptionmetrics/models/torch_detection.py, if len(boxes) == 0, we now convert boxes to an empty tensor of shape (0, 4) with float32 dtype before wrapping it as tv_tensors.BoundingBoxes thereby preventing mismatch during eval().

Before the fix :
<img width="1920" height="774" alt="Screenshot from 2026-03-05 03-27-43" src="https://github.com/user-attachments/assets/b889af23-0a1e-44d6-8d0c-fc1c4d55e5c1" />

After applying fix :
<img width="1900" height="765" alt="image" src="https://github.com/user-attachments/assets/d88c2c46-7a70-47f2-b8cf-a7940ade8b5f" />

@dpascualhe 