### PR TITLE
[Bug-fix][UI] Truncate long file names in the datasetviewer tab

### DIFF
--- a/tabs/dataset_viewer.py
+++ b/tabs/dataset_viewer.py
@@ -172,17 +172,6 @@ def dataset_viewer_tab():
     sample_images = image_files[start_idx : start_idx + IMAGES_PER_PAGE]
     image_paths = [os.path.join(img_dir, img_name) for img_name in sample_images]
 
-    # CSS for compact image grid
-    st.markdown(
-        """
-        <style>
-        .image-selector__image, .image-selector__image img {
-            max-width: 120px; max-height: 120px; width: 120px; height: 120px; object-fit: contain;
-        }
-        </style>
-    """,
-        unsafe_allow_html=True,
-    )
 
     # Navigation
     col1, col2, col3, col4 = st.columns([0.5, 9.5, 0.5, 0.5])


### PR DESCRIPTION
@dpascualhe 
This PR fixes #407 by truncating the file names (while still retaining file extension) before passing them as captions to prevent overlapping.

Ps: I formatted the file with black hence the random change in adding parantheses.

Before fix : 
<img width="1292" height="890" alt="Screenshot from 2026-03-06 23-02-00" src="https://github.com/user-attachments/assets/65d20563-42f1-4393-9e1a-24a12df63bd5" />
 
After fix :
<img width="1292" height="890" alt="Screenshot from 2026-03-06 23-17-10" src="https://github.com/user-attachments/assets/389383dd-6f54-409a-97af-e0089a1d1b30" />
