### PR TITLE
 add normalized_weighted averaging method to get_averaged_metric()

### DIFF
--- a/perceptionmetrics/utils/segmentation_metrics.py
+++ b/perceptionmetrics/utils/segmentation_metrics.py
@@ -227,7 +227,7 @@ class SegmentationMetricsFactory:
 
         :param metric: Name of the metric to compute
         :type metric: str
-        :param method: Method to use for averaging ('macro', 'micro' or 'weighted')
+        :param method: Method to use for averaging ('macro', 'micro', 'weighted' or 'normalized_weighted')
         :type method: str
         :param weights: Weights for weighted averaging, defaults to None
         :type weights: Optional[np.ndarray], optional
@@ -243,12 +243,14 @@ class SegmentationMetricsFactory:
             assert (
                 weights is not None
             ), "Weights should be provided for weighted averaging"
-            
+            return float(np.nansum(metric(per_class=True) * weights))
+        if method == "normalized_weighted":
+            assert (
+                weights is not None
+            ), "Weights should be provided for weighted averaging"
             weight_sum = np.nansum(weights)
-            # Prevent division by zero if the sum of weights is zero
             if weight_sum == 0:
                 return math.nan
-            
             return float(np.nansum(metric(per_class=True) * weights) / weight_sum)
         raise ValueError(f"Unknown method {method}")
 


### PR DESCRIPTION
Closes #406

As suggested by @dpascualhe, this PR adds `normalized_weighted` as a new averaging method rather than modifying the existing `weighted` behavior.

**New method:**
`normalized_weighted` divides by the sum of weights, ensuring the result stays within [0, 1].

**Existing behavior unchanged:**
`weighted` continues to return the raw dot product for backward compatibility.

**Changes:**
- perceptionmetrics/utils/segmentation_metrics.py: added normalized_weighted method.