### PR TITLE
Fix incorrect filename in label file assertion error message

### DIFF
--- a/perceptionmetrics/datasets/generic.py
+++ b/perceptionmetrics/datasets/generic.py
@@ -102,7 +102,7 @@ def build_dataset(
             label_fname = "".join(a + (b or "") for a, b in label_fname)
 
             assert os.path.isfile(data_fname), f"Data file not found: {data_fname}"
-            assert os.path.isfile(label_fname), f"Label file not found: {data_fname}"
+            assert os.path.isfile(label_fname), f"Label file not found: {label_fname}"
 
             sample_name = "_".join(sample_matches)
             dataset[sample_name] = (data_fname, label_fname, split)


### PR DESCRIPTION
Closes #410 

Fixes an incorrect filename used in the label file assertion error message in `perceptionmetrics/datasets/generic.py`.

The error message previously referenced data_fname instead of label_fname, which could make debugging dataset issues confusing.


Before:
```
assert os.path.isfile(label_fname), f"Label file not found: {data_fname}"
```

After:

```
assert os.path.isfile(label_fname), f"Label file not found: {label_fname}"
```
