### PR TITLE
Fix argument order bug in OnnxImageSegmentationModel initialization

### DIFF
--- a/perceptionmetrics/models/onnx.py
+++ b/perceptionmetrics/models/onnx.py
@@ -2,5 +2,11 @@ from perceptionmetrics.models.segmentation import ImageSegmentationModel
 
 
 class OnnxImageSegmentationModel(ImageSegmentationModel):
-    def __init__(self, model, model_type, ontology_fname, model_cfg, model_fname):
-        super().__init__(model, model_type, ontology_fname, model_cfg, model_fname)
+    def __init__(self, model, model_type, model_cfg, ontology_fname, model_fname):
+        super().__init__(
+            model=model,
+            model_type=model_type,
+            model_cfg=model_cfg,
+            ontology_fname=ontology_fname,
+            model_fname=model_fname,
+        )


### PR DESCRIPTION
Closes #416

## Problem
`OnnxImageSegmentationModel.__init__` (perceptionmetrics/models/onnx.py) defined its parameters as:
(model, model_type, ontology_fname, model_cfg, model_fname) and passed them positionally to `super().__init__()`.

However, the parent `ImageSegmentationModel.__init__` (perceptionmetrics/models/segmentation.py) expects:
(model, model_type, model_cfg, ontology_fname, model_fname)

This caused `model_cfg` and `ontology_fname` to be swapped when passed to the parent constructor. This leads to incorrect preprocessing, wrong class label mappings, or runtime errors.

## Fix
- Corrected the parameter order in `OnnxImageSegmentationModel.__init__`
- Used keyword arguments in the `super().__init__()` call to prevent similar argument-order bugs in the future