### PR TITLE
fix: correct COCO registry key from coco_detection to coco_image_detection

### DIFF
--- a/perceptionmetrics/datasets/__init__.py
+++ b/perceptionmetrics/datasets/__init__.py
@@ -36,4 +36,4 @@ REGISTRY = {
 }
 
 if CocoDataset is not None:
-    REGISTRY["coco_detection"] = CocoDataset
+    REGISTRY["coco_image_detection"] = CocoDataset


### PR DESCRIPTION
Closes #426 

## Summary

The CLI constructs dataset registry keys using `{dataset_format}_{input_type}_{task}`. 

For COCO detection this becomes `coco_image_detection`, but the dataset is currently registered as `coco_detection`, causing the lookup to fail.

## Fix

Update the registry key to match the CLI naming convention.

```python
# perceptionmetrics/datasets/__init__.py

# Before
REGISTRY["coco_detection"] = CocoDataset

# After
REGISTRY["coco_image_detection"] = CocoDataset
```
