### PR TITLE
Fix YOLODataset loader when names field in data.yaml is defined as a …

### DIFF
--- a/perceptionmetrics/datasets/yolo.py
+++ b/perceptionmetrics/datasets/yolo.py
@@ -33,8 +33,13 @@ def build_dataset(
     assert os.path.isdir(dataset_dir), f"Dataset directory not found: {dataset_dir}"
 
     # Build ontology from dataset configuration
+
     ontology = {}
-    for idx, name in dataset_info["names"].items():
+    names = dataset_info["names"]
+    # Support both list and dictionary formats for YOLO datasets
+    if isinstance(names, list):
+        names = {i: name for i, name in enumerate(names)}
+    for idx, name in names.items():
         ontology[name] = {
             "idx": idx,
             "rgb": [0, 0, 0],  # Placeholder; YAML doesn't define RGB colors


### PR DESCRIPTION
Fixes #432

Many YOLO datasets (such as Ultralytics datasets like COCO128) define class names in `data.yaml` as a list:

names: ["person", "car", "dog"]

However, the current implementation assumes that `names` is a dictionary and calls `.items()`, which causes the error:

'list' object has no attribute 'items'

This patch converts the list format into a dictionary using `enumerate`, allowing the loader to support both formats.