### PR TITLE
fix: add input validation and user-friendly error messages in evaluator tab

### DIFF
--- a/tabs/evaluator.py
+++ b/tabs/evaluator.py
@@ -57,8 +57,12 @@ def evaluator_tab():
                         f"✅ Dataset loaded: {dataset_path} ({split} split) - {len(dataset.dataset)} samples"
                     )
                 else:
-                    st.warning(
-                        "⚠️ Dataset files not found. Please check the dataset path and split in the sidebar."
+                    st.error(
+                        f"❌ COCO dataset files not found at expected paths:\n"
+                        f"- Images: `images/{split}2017/`\n"
+                        f"- Annotations: `annotations/instances_{split}2017.json`\n\n"
+                        f"Please verify your dataset folder follows this structure. "
+                        f"Custom COCO versions (e.g. 2014) are not yet supported."
                     )
             else:
                 st.warning(
@@ -84,6 +88,14 @@ def evaluator_tab():
             "⚠️ No model loaded. Please load a model using the 'Load Model' button in the sidebar."
         )
 
+    # Show hint if button will be disabled
+    if not dataset_available and not model_available:
+        st.info("ℹ️ Load both a dataset and a model from the sidebar to enable evaluation.")
+    elif not dataset_available:
+        st.info("ℹ️ Load a dataset from the sidebar to enable evaluation.")
+    elif not model_available:
+        st.info("ℹ️ Load a model from the sidebar to enable evaluation.")
+        
     # Evaluation configuration
     st.markdown("### Evaluation Configuration")
 
@@ -132,6 +144,20 @@ def evaluator_tab():
             )
             return
 
+        # Validate predictions output directory before starting evaluation
+        if save_predictions or save_visualizations:
+            if not predictions_outdir_input or not predictions_outdir_input.strip():
+                st.error(
+                    "❌ Please provide a Predictions Output Directory before running evaluation."
+                )
+                return
+            if os.path.isfile(predictions_outdir_input.strip()):
+                st.error(
+                    "❌ The specified output path is a file, not a directory. "
+                    "Please provide a valid directory path."
+                )
+                return
+            
         # Prepare evaluation
         with st.spinner("Running evaluation..."):
             try:


### PR DESCRIPTION
## Summary

This PR fixes three input validation gaps in the Evaluator tab 
that caused silent failures or confusing UX for new users.

Closes #436

## Changes Made

All changes are in `tabs/evaluator.py`.

### Fix 1 — Clear error message for COCO path mismatch
Replaced the generic `st.warning()` with a detailed `st.error()` 
that shows exactly which paths are expected, instead of a vague 
"files not found" message.

### Fix 2 — Validate `predictions_outdir` before evaluation runs
Added pre-run validation that checks:
- Output directory field is not empty
- Output path is not a file (must be a directory)

This prevents crashes mid-evaluation caused by invalid paths.

### Fix 3 — Explain why "Run Evaluation" button is disabled
Added `st.info()` hints above the button that tell the user 
exactly what is missing (dataset, model, or both) instead of 
showing a greyed-out button with no explanation.

## Files Changed
- `tabs/evaluator.py`

## Testing
These are UI/UX fixes in Streamlit. To verify:
1. Run `streamlit run app.py`
2. Open Evaluator tab without loading dataset/model → 
   see info hints ✅
3. Enter wrong COCO path → see clear error message ✅
4. Check "Save Predictions" and click Run without 
   providing output dir → see validation error ✅

Github: @vinitjain2005