### PR TITLE
fix: sort image files in dataset viewer for consistent ordering

### DIFF
--- a/tabs/dataset_viewer.py
+++ b/tabs/dataset_viewer.py
@@ -148,9 +148,9 @@ def dataset_viewer_tab():
     dataset = st.session_state[dataset_key]
 
     # Get image files
-    image_files = [
+    image_files = sorted([
         f for f in os.listdir(img_dir) if f.lower().endswith((".jpg", ".jpeg", ".png"))
-    ]
+])
     if not image_files:
         st.warning("No images found.")
         return


### PR DESCRIPTION
## Summary

Fixes inconsistent image ordering in the Dataset Viewer tab by 
wrapping `os.listdir()` with `sorted()`.

Closes #438

## Problem

`os.listdir()` returns files in arbitrary filesystem order which 
is not guaranteed to be consistent across reloads. This caused:

- Page 1 showing different images on every reload
- Pagination becoming unreliable across sessions
- Search "Go to image" feature sending users to wrong images

## Fix

A one-line change in `tabs/dataset_viewer.py`:
```python
# Before
image_files = [
    f for f in os.listdir(img_dir) 
    if f.lower().endswith((".jpg", ".jpeg", ".png"))
]

# After
image_files = sorted([
    f for f in os.listdir(img_dir) 
    if f.lower().endswith((".jpg", ".jpeg", ".png"))
])
```

## Files Changed
- `tabs/dataset_viewer.py`

## Testing
1. Open Dataset Viewer tab
2. Load any COCO or YOLO dataset
3. Note image order on Page 1
4. Reload the page
5. Page 1 now shows same images in same order 

Github: @vinitjain2005