### PR TITLE
Fix: device auto-detection in GUI and specific exception handling in model loading

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from tabs.dataset_viewer import dataset_viewer_tab
 from tabs.inference import inference_tab
 from tabs.evaluator import evaluator_tab
 from perceptionmetrics.utils.gui import browse_folder
+from perceptionmetrics.utils.torch import get_device_info
 
 
 def browse_dataset_path():
@@ -18,6 +19,8 @@ PAGES = {
     "Evaluator": evaluator_tab,
 }
 
+best_device, available_devices = get_device_info()
+
 # Initialize commonly used session state keys
 st.session_state.setdefault("dataset_path", "")
 st.session_state.setdefault("dataset_type", "YOLO")
@@ -26,18 +29,7 @@ st.session_state.setdefault("config_option", "Manual Configuration")
 st.session_state.setdefault("confidence_threshold", 0.5)
 st.session_state.setdefault("nms_threshold", 0.5)
 st.session_state.setdefault("max_detections", 100)
-st.session_state.setdefault(
-    "device",
-    (
-        "cuda"
-        if torch.cuda.is_available()
-        else (
-            "mps"
-            if (hasattr(torch.backends, "mps") and torch.backends.mps.is_available())
-            else "cpu"
-        )
-    ),
-)
+st.session_state.setdefault("device", best_device)
 st.session_state.setdefault("batch_size", 1)
 st.session_state.setdefault("evaluation_step", 5)
 st.session_state.setdefault("detection_model", None)
@@ -137,14 +129,6 @@ with st.sidebar:
                     key="max_detections",
                 )
             with col2:
-                available_devices = []
-
-                if torch.cuda.is_available():
-                    available_devices.append("cuda")
-                if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-                    available_devices.append("mps")
-                available_devices.append("cpu")
-
                 st.selectbox(
                     "Device",
                     available_devices,

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import streamlit as st
+import torch
 from tabs.dataset_viewer import dataset_viewer_tab
 from tabs.inference import inference_tab
 from tabs.evaluator import evaluator_tab
@@ -25,7 +26,18 @@ st.session_state.setdefault("config_option", "Manual Configuration")
 st.session_state.setdefault("confidence_threshold", 0.5)
 st.session_state.setdefault("nms_threshold", 0.5)
 st.session_state.setdefault("max_detections", 100)
-st.session_state.setdefault("device", "cuda")
+st.session_state.setdefault(
+    "device",
+    (
+        "cuda"
+        if torch.cuda.is_available()
+        else (
+            "mps"
+            if (hasattr(torch.backends, "mps") and torch.backends.mps.is_available())
+            else "cpu"
+        )
+    ),
+)
 st.session_state.setdefault("batch_size", 1)
 st.session_state.setdefault("evaluation_step", 5)
 st.session_state.setdefault("detection_model", None)
@@ -125,9 +137,17 @@ with st.sidebar:
                     key="max_detections",
                 )
             with col2:
+                available_devices = []
+
+                if torch.cuda.is_available():
+                    available_devices.append("cuda")
+                if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                    available_devices.append("mps")
+                available_devices.append("cpu")
+
                 st.selectbox(
                     "Device",
-                    ["cpu", "cuda", "mps"],
+                    available_devices,
                     key="device",
                 )
                 st.selectbox(

--- a/app.py
+++ b/app.py
@@ -1,5 +1,4 @@
 import streamlit as st
-import torch
 from tabs.dataset_viewer import dataset_viewer_tab
 from tabs.inference import inference_tab
 from tabs.evaluator import evaluator_tab

--- a/perceptionmetrics/models/torch_detection.py
+++ b/perceptionmetrics/models/torch_detection.py
@@ -16,6 +16,7 @@ from perceptionmetrics.datasets import detection as detection_dataset
 from perceptionmetrics.models import detection as detection_model
 from perceptionmetrics.utils import detection_metrics as um
 from perceptionmetrics.utils import image as ui
+from perceptionmetrics.utils.torch import get_device_info
 
 
 def get_resize_args(resize_cfg: Dict[str, Any]) -> Dict[str, Any]:
@@ -250,15 +251,13 @@ class TorchImageDetectionModel(detection_model.ImageDetectionModel):
         :type model_cfg: str
         :param ontology_fname: JSON file containing model output ontology
         :type ontology_fname: str
-        :param device: torch.device to use (optional). If not provided, will auto-select cuda, mps, or cpu.
+        :param device: torch.device to use (optional). If not provided, best available device is auto-selected using get_device_info() from perceptionmetrics.utils.torch.
+        :type device: torch.device
         """
         # Get device (GPU, MPS, or CPU) if not provided
         if device is None:
-            self.device = torch.device(
-                "cuda"
-                if torch.cuda.is_available()
-                else "mps" if torch.backends.mps.is_available() else "cpu"
-            )
+            best_device, _ = get_device_info()
+            self.device = torch.device(best_device)
         else:
             self.device = device
 

--- a/perceptionmetrics/models/torch_detection.py
+++ b/perceptionmetrics/models/torch_detection.py
@@ -269,12 +269,18 @@ class TorchImageDetectionModel(detection_model.ImageDetectionModel):
             try:
                 model = torch.jit.load(model, map_location=self.device)
                 model_type = "compiled"
-            except Exception:
-                print(
-                    "Model is not a TorchScript model. Loading as native PyTorch model."
-                )
-                model = torch.load(model, map_location=self.device, weights_only=False)
-                model_type = "native"
+            except RuntimeError:
+                try:
+                    model = torch.load(
+                        model, map_location=self.device, weights_only=False
+                    )
+                    model_type = "native"
+                except Exception as e:
+                    raise ValueError(
+                        f"Failed to load model. "
+                        f"Ensure it is a valid PyTorch or TorchScript model. Error : {e}"
+                    )
+
         elif isinstance(model, torch.nn.Module):
             model_fname = None
             model_type = "native"

--- a/perceptionmetrics/utils/torch.py
+++ b/perceptionmetrics/utils/torch.py
@@ -63,3 +63,23 @@ def unsqueeze_data(data: Union[tuple, list], dim: int = 0) -> Union[tuple, list]
         return data.unsqueeze(dim)
     else:
         return data
+
+
+def get_device_info():
+    """Get the best available device(CPU or GPU) and list of available devices.
+
+    :return: Tuple of (best_device, available_devices) where best_device is a string and avaible_devices is a list of strings.
+    :rtype: tuple(str, list[str])
+    """
+
+    available_devices = []
+
+    if torch.cuda.is_available():
+        available_devices.append("cuda")
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        available_devices.append("mps")
+    available_devices.append("cpu")
+
+    best_device = available_devices[0]
+
+    return best_device, available_devices


### PR DESCRIPTION
Fixes #419

## Changes

### 1. app.py — Device auto-detection

The device dropdown previously defaulted to `cuda` even on systems where CUDA was not available, which caused confusing errors on CPU-only machines.

Fixed by:
- Defaulting to `cuda` when CUDA is available
- Using `mps` on Apple Silicon if available
- Falling back to `cpu` otherwise
- Showing only devices that are actually available in the dropdown

### 2. torch_detection.py — Specific exception handling

The model loading logic previously used a bare `except Exception`, which caught unrelated errors and made debugging difficult.

Fixed by:
- Catching `RuntimeError` specifically when `torch.jit.load` fails
- Falling back to `torch.load`
- Adding separate error handling for invalid model formats

## Testing

Tested on a CPU-only machine (Ubuntu 24, Python 3.12, PyTorch 2.4.1+cpu):

- GUI now defaults to `cpu`
- `yolov8n.torchscript` loads without misleading warnings
- Invalid model formats now produce clearer errors