### PR TITLE
fix: rename duplicate 'Detection Results' heading to 'Detection Details' in inference tab

### DIFF
--- a/tabs/inference.py
+++ b/tabs/inference.py
@@ -100,7 +100,7 @@ def inference_tab():
                         st.metric("Max Confidence", f"{max_confidence:.3f}")
 
                     # Display and download detection results
-                    st.markdown("#### Detection Results")
+                    st.markdown("#### Detection Details")
 
                     # Convert predictions to JSON format
                     detection_results = []


### PR DESCRIPTION
## Summary
Renames the duplicate "Detection Results" heading in the Inference tab 
to "Detection Details" for better UI clarity.

Closes #445 

## Problem
In the Inference tab, the heading "Detection Results" appeared twice:
- Once above the annotated image
- Again above the JSON expander section

This caused confusion for the user as both sections looked identical in title.

## Fix
Renamed the second heading from "Detection Results" to "Detection Details":

# Before
st.markdown("#### Detection Results")  # duplicate

# After
st.markdown("#### Detection Details")  # clear and distinct

## Files Changed
- `tabs/inference.py`

## Testing
1. Load a model from the sidebar
2. Upload any image in the Inference tab
3. Run inference
4. Confirm headings now read:
   - "Detection Results" → above the image ✅
   - "Detection Details" → above the JSON expander ✅

## Checklist
- [x] Minimal, focused change
- [x] No new dependencies introduced

Github: @vinitjain2005