### PR TITLE
fix: use perf_counter and guard cuda.synchronize() for accurate CPU timing

### DIFF
--- a/perceptionmetrics/models/torch_detection.py
+++ b/perceptionmetrics/models/torch_detection.py
@@ -137,15 +137,17 @@ def get_computational_cost(
     # Measure inference time
     inference_times = []
     for _ in range(runs):
-        torch.cuda.synchronize()
-        start = time.time()
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        start = time.perf_counter()
         with torch.no_grad():
             if hasattr(model, "inference"):
                 model.inference(*dummy_tuple)
             else:
                 model(*dummy_tuple)
-        torch.cuda.synchronize()
-        inference_times.append(time.time() - start)
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        inference_times.append(time.perf_counter() - start)
 
     # Get number of parameters
     n_params = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
## Summary

Fixes inaccurate inference timing in `get_computational_cost()` when running on CPU-only machines.

Closes #453 

## Problem

The current implementation calls `torch.cuda.synchronize()` 
unconditionally and uses `time.time()` for timing:
```python
# Before
torch.cuda.synchronize()  # no-op on CPU
start = time.time()       # low resolution on Windows (15ms)
...
torch.cuda.synchronize()
inference_times.append(time.time() - start)
```

This causes two problems:
- `torch.cuda.synchronize()` is a no-op on CPU — it only works with CUDA devices
- `time.time()` has low resolution on Windows (15ms granularity) causing timing to show 0ms or jump in 15ms chunks

## Fix
```python
# After
if torch.cuda.is_available():
    torch.cuda.synchronize()
start = time.perf_counter()  # high resolution on all platforms
...
if torch.cuda.is_available():
    torch.cuda.synchronize()
inference_times.append(time.perf_counter() - start)
```

## Changes
- Only call `torch.cuda.synchronize()` when CUDA is available
- Replace `time.time()` with `time.perf_counter()` for accurate sub-millisecond timing on all platforms

## Files Changed
- `perceptionmetrics/models/torch_detection.py`

## Testing

On CPU (CUDA not available):

**Before fix:** timing shows 0ms or jumps of 15ms on Windows

**After fix:** timing shows accurate sub-millisecond results

## References
- PyTorch docs: `torch.cuda.synchronize()` only synchronizes 
  CUDA device operations
- Python docs: `time.perf_counter()` is the recommended 
  high-resolution timer for benchmarking

Github: @vinitjain2005
