### PR TITLE
fix: write sample_pred per-sample instead of full batch pred in .tofile loop

### DIFF
--- a/perceptionmetrics/models/torch_segmentation.py
+++ b/perceptionmetrics/models/torch_segmentation.py
@@ -774,7 +774,7 @@ class TorchLiDARSegmentationModel(segmentation_model.LiDARSegmentationModel):
                             sample_df.to_csv(
                                 os.path.join(predictions_outdir, f"{sample_name}.csv")
                             )
-                        pred.tofile(
+                        sample_pred.tofile(
                             os.path.join(predictions_outdir, f"{sample_name}.bin")
                         )
 


### PR DESCRIPTION
Closes #455 

## Summary
Fixes a bug in `TorchLiDARSegmentationModel.eval()` where `.bin` prediction files were being written with the entire batch instead of the per-sample slice.

## Change
- `perceptionmetrics/models/torch_segmentation.py` line 777
- `pred.tofile(...)` -> `sample_pred.tofile(...)`

## Testing
Verified with a minimal reproduction script simulating a batch of 3 samples.
Before fix: every `.bin` file contained 30 values (full batch).
After fix: each `.bin` file correctly contains 10 values (per-sample).