### PR TITLE
Add Windows setup instructions for venv (fixes #457)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,18 +106,28 @@ Install dependencies and activate poetry environment (you can get out of the Poe
 poetry install
 poetry shell
 ```
+
 ### Using venv
 Create your virtual environment:
-```
-mkdir .venv
-python3 -m venv .venv
-```
 
-Activate your environment and install as pip package:
-```
+```bash
+# Linux / macOS
+mkdir -p .venv
+python3 -m venv .venv
+
+# Windows
+python -m venv .venv
+
+# Activate your environment and install as pip package:
+
+# Linux / macOS
 source .venv/bin/activate
 pip install -e .
-```
+
+# Windows
+.venv\Scripts\activate
+pip install -e .
+
 
 ## Common
 Install your deep learning framework of preference in your environment. We have tested:


### PR DESCRIPTION
###  Description
Added Windows setup instructions for creating and activating a virtual environment in the README.

###  Problem
The README only included Linux/macOS steps, making it difficult for Windows users to set up the project.

###  Changes Made
- Added Windows-specific commands for:
  - Creating virtual environment
  - Activating environment
  - Installing dependencies

###  Related Issue
Fixes #457