### PR TITLE
fix: store cuda_available variable and extend perf_counter fix to all get_computational_cost functions

### DIFF
--- a/perceptionmetrics/models/tf_segmentation.py
+++ b/perceptionmetrics/models/tf_segmentation.py
@@ -511,13 +511,13 @@ class TensorflowImageSegmentationModel(ImageSegmentationModel):
             if has_gpu:
                 tf.config.experimental.set_synchronous_execution(True)
 
-            start_time = time.time()
+            start_time = time.perf_counter()
             self.inference(dummy_input)
 
             if has_gpu:
                 tf.config.experimental.set_synchronous_execution(True)
 
-            inference_times.append(time.time() - start_time)
+            inference_times.append(time.perf_counter() - start_time)
 
         # Retrieve computational cost information
         result = {

--- a/perceptionmetrics/models/torch_detection.py
+++ b/perceptionmetrics/models/torch_detection.py
@@ -135,17 +135,20 @@ def get_computational_cost(
                 model(*dummy_tuple)
 
     # Measure inference time
+    cuda_available = torch.cuda.is_available()
     inference_times = []
     for _ in range(runs):
-        torch.cuda.synchronize()
-        start = time.time()
+        if cuda_available:
+            torch.cuda.synchronize()
+        start = time.perf_counter()
         with torch.no_grad():
             if hasattr(model, "inference"):
                 model.inference(*dummy_tuple)
             else:
                 model(*dummy_tuple)
-        torch.cuda.synchronize()
-        inference_times.append(time.time() - start)
+        if cuda_available:
+            torch.cuda.synchronize()
+        inference_times.append(time.perf_counter() - start)
 
     # Get number of parameters
     n_params = sum(p.numel() for p in model.parameters())

--- a/perceptionmetrics/models/torch_segmentation.py
+++ b/perceptionmetrics/models/torch_segmentation.py
@@ -513,6 +513,7 @@ class TorchImageSegmentationModel(segmentation_model.ImageSegmentationModel):
             size_mb = None
 
         # Measure inference time with GPU synchronization
+        cuda_available = torch.cuda.is_available()
         dummy_tuple = dummy_input if isinstance(dummy_input, tuple) else (dummy_input,)
 
         for _ in range(warm_up_runs):
@@ -520,11 +521,13 @@ class TorchImageSegmentationModel(segmentation_model.ImageSegmentationModel):
 
         inference_times = []
         for _ in range(runs):
-            torch.cuda.synchronize()
-            start_time = time.time()
+            if cuda_available:
+                torch.cuda.synchronize()
+            start_time = time.perf_counter()
             self.inference(dummy_tuple[0])
-            torch.cuda.synchronize()
-            end_time = time.time()
+            if cuda_available:
+                torch.cuda.synchronize()
+            end_time = time.perf_counter()
             inference_times.append(end_time - start_time)
 
         result = {
@@ -830,8 +833,9 @@ class TorchLiDARSegmentationModel(segmentation_model.LiDARSegmentationModel):
             size_mb = None
 
         # Measure inference time with GPU synchronization
+        cuda_available = torch.cuda.is_available()
         for _ in range(warm_up_runs):
-            if "o3d" in self.model_format:  # reset random sampling for Open3D-ML models
+            if "o3d" in self.model_format:
                 subsampled_points, _, sampler, _, _, _ = sample
                 self._reset_sampler(sampler, subsampled_points.shape[0], self.n_classes)
 
@@ -839,14 +843,16 @@ class TorchLiDARSegmentationModel(segmentation_model.LiDARSegmentationModel):
 
         inference_times = []
         for _ in range(runs):
-            if "o3d" in self.model_format:  # reset random sampling for Open3D-ML models
+            if "o3d" in self.model_format:
                 subsampled_points, _, sampler, _, _, _ = sample
                 self._reset_sampler(sampler, subsampled_points.shape[0], self.n_classes)
-            torch.cuda.synchronize()
-            start_time = time.time()
+            if cuda_available:
+                torch.cuda.synchronize()
+            start_time = time.perf_counter()
             self.inference(sample, self.model, self.model_cfg)
-            torch.cuda.synchronize()
-            end_time = time.time()
+            if cuda_available:
+                torch.cuda.synchronize()
+            end_time = time.perf_counter()
             inference_times.append(end_time - start_time)
 
         result = {

--- a/perceptionmetrics/models/torch_segmentation.py
+++ b/perceptionmetrics/models/torch_segmentation.py
@@ -835,7 +835,7 @@ class TorchLiDARSegmentationModel(segmentation_model.LiDARSegmentationModel):
         # Measure inference time with GPU synchronization
         cuda_available = torch.cuda.is_available()
         for _ in range(warm_up_runs):
-            if "o3d" in self.model_format:
+            if "o3d" in self.model_format:  # reset random sampling for Open3D-ML models
                 subsampled_points, _, sampler, _, _, _ = sample
                 self._reset_sampler(sampler, subsampled_points.shape[0], self.n_classes)
 

--- a/perceptionmetrics/models/torch_segmentation.py
+++ b/perceptionmetrics/models/torch_segmentation.py
@@ -843,7 +843,7 @@ class TorchLiDARSegmentationModel(segmentation_model.LiDARSegmentationModel):
 
         inference_times = []
         for _ in range(runs):
-            if "o3d" in self.model_format:
+            if "o3d" in self.model_format:  # reset random sampling for Open3D-ML models
                 subsampled_points, _, sampler, _, _, _ = sample
                 self._reset_sampler(sampler, subsampled_points.shape[0], self.n_classes)
             if cuda_available:


### PR DESCRIPTION
## Summary

This PR extends the timing fix originally proposed in the closed PR to all `get_computational_cost()` functions across the library, and also addresses the review comment to store `torch.cuda.is_available()` in a variable instead of calling it on every loop iteration.

Closes #453

## Problem

The `get_computational_cost()` functions across multiple files had two issues:

1. `torch.cuda.synchronize()` was called unconditionally on every iteration — it is a no-op on CPU and was designed only for CUDA devices

2. `time.time()` was used for timing — it has low resolution on Windows (15ms granularity) causing timing to show 0ms or jump in 15ms chunks

3. `torch.cuda.is_available()` was being called on every loop iteration instead of being stored once as a variable

## Fix
```python
# Before
for _ in range(runs):
    torch.cuda.synchronize()        # unconditional, no-op on CPU
    start = time.time()             # low resolution on Windows
    ...
    torch.cuda.synchronize()
    inference_times.append(time.time() - start)

# After
cuda_available = torch.cuda.is_available()  # stored once
for _ in range(runs):
    if cuda_available:
        torch.cuda.synchronize()
    start = time.perf_counter()     # high resolution on all platforms
    ...
    if cuda_available:
        torch.cuda.synchronize()
    inference_times.append(time.perf_counter() - start)
```

## Files Changed

- `perceptionmetrics/models/torch_detection.py`
  - Fixed standalone `get_computational_cost()` function
  
- `perceptionmetrics/models/torch_segmentation.py`
  - Fixed `TorchImageSegmentationModel.get_computational_cost()`
  - Fixed `TorchLiDARSegmentationModel.get_computational_cost()`

- `perceptionmetrics/models/tf_segmentation.py`
  - Fixed `TensorflowImageSegmentationModel.get_computational_cost()`
  - Note: Uses `has_gpu` variable (already stored before loop)
    and replaces `time.time()` with `time.perf_counter()`

## Impact

Every user running computational cost estimation on CPU gets accurate timing results. This is especially relevant since CUDA is optional and most contributors and new users run on CPU-only machines.

## References

- PyTorch docs: `torch.cuda.synchronize()` only synchronizes CUDA device operations
- Python docs: `time.perf_counter()` is the recommended high-resolution timer for benchmarking

Github: @vinitjain2005