### PR TITLE
fix(evaluator): Disable Run Evaluation button when output directory is missing

### DIFF
--- a/tabs/evaluator.py
+++ b/tabs/evaluator.py
@@ -120,11 +120,23 @@ def evaluator_tab():
         help="JSON file for translating between dataset and model ontologies",
     )
 
+    # Disable Run Evaluation button if output dir is missing
+    output_dir_required = save_predictions or save_visualizations
+    output_dir_missing = output_dir_required and not (
+        predictions_outdir_input and predictions_outdir_input.strip()
+    )
+
+    if output_dir_missing:
+        st.warning(
+            "⚠️ Please provide a Predictions Output Directory to enable evaluation "
+            "when 'Save Predictions' or 'Save Visualizations' is turned on."
+        )
+
     # Run evaluation button
     if st.button(
         "🚀 Run Evaluation",
         type="primary",
-        disabled=not (dataset_available and model_available),
+        disabled=not (dataset_available and model_available) or output_dir_missing,
     ):
         if not dataset_available or not model_available:
             st.error(


### PR DESCRIPTION
## Summary
This PR addresses the review feedback on the Evaluator tab by replacing the post-click error validation with upfront button disabling logic.

## Changes Made

### Replaced post-click validation with upfront button disabling
- Previously, if `Save Predictions` or `Save Visualizations` was enabled but no output directory was provided, the error was only shown after clicking the Run Evaluation button
- Now the `Run Evaluation` button is disabled upfront and a warning is shown immediately explaining why the button is disabled
- The button re-enables automatically once a valid output directory is provided

## Before vs After

### Before
- User checks Save Predictions
- User leaves output directory empty
- User clicks Run Evaluation
- Error appears and execution stops

### After
- User checks Save Predictions
- Warning appears immediately
- Run Evaluation button is greyed out
- User fills in the directory
- Warning disappears and button becomes clickable

## Related Issue
Closes #436

Github: @vinitjain2005 