### PR TITLE
Fix #471: Add a torch dep group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,10 @@ furo = "^2025.12.19"
 [tool.poetry.group.test.dependencies]
 pytest = "^8.0.0"
 
+[tool.poetry.group.torch.dependencies]
+torch = "2.4.1"
+torchvision = "0.19.1"
+
 [tool.poetry.scripts]
 pm_evaluate = "perceptionmetrics.cli.evaluate:evaluate"
 pm_batch = "perceptionmetrics.cli.batch:batch"


### PR DESCRIPTION
Fixes: #471
This PR adds a torch dep group. It addresses the following:
- Installation ambiguity, where users had to manually guess compatible Torch and Torchvision versions.
- Reproducibility issues, by standardizing on a known-good recommended pair for Torch installs via an optional subgroup approach.

I can add a similar group for tensorflow as well if required.