### PR TITLE
Fix #464: Replaced harcoded paths with placeholder

### DIFF
--- a/examples/tutorial_image_detection.ipynb
+++ b/examples/tutorial_image_detection.ipynb
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -56,27 +56,31 @@
    ],
    "source": [
     "# Initialize COCO dataset\n",
-    "# Using existing COCO data paths\n",
-    "# img_dir = \"/home/dpascualhe/datasets/coco/val2017\"\n",
-    "# ann_file = \"/home/dpascualhe/datasets/coco/annotations/instances_val2017.json\"\n",
+    "# Update these placeholders with your local COCO paths before running\n",
     "\n",
-    "img_dir = \"/Users/sakprave/Downloads/Coco/images/val2017\"\n",
-    "ann_file = \"/Users/sakprave/Downloads/Coco/annotations/instances_val2017.json\"\n",
+    "img_dir = \"<PATH_TO_COCO_VAL2017_IMAGES>\"\n",
+    "ann_file = \"<PATH_TO_COCO_INSTANCES_VAL2017_JSON>\"\n",
     "\n",
+    "dataset = None\n",
     "\n",
     "# Check if files exist\n",
-    "if not os.path.exists(img_dir) or not os.path.exists(ann_file):\n",
-    "    print(\"COCO data not found. Please check the paths above.\")\n",
+    "if img_dir.startswith(\"<PATH_TO_\") or ann_file.startswith(\"<PATH_TO_\"):\n",
+    "    print(\"Please set 'img_dir' and 'ann_file' to your local COCO paths before running this cell.\")\n",
+    "elif not os.path.exists(img_dir) or not os.path.exists(ann_file):\n",
+    "    print(\"COCO data not found. Please check that both paths exist on your machine.\")\n",
     "else:\n",
-    "    # Load dataset\n",
-    "    dataset = CocoDataset(annotation_file=ann_file, image_dir=img_dir, split=\"train\")\n",
-    "    print(f\"Dataset loaded with {len(dataset.dataset)} samples\")\n",
-    "    print(f\"Number of classes: {len(dataset.ontology)}\")"
+    "    try:\n",
+    "        # Load dataset\n",
+    "        dataset = CocoDataset(annotation_file=ann_file, image_dir=img_dir, split=\"train\")\n",
+    "        print(f\"Dataset loaded with {len(dataset.dataset)} samples\")\n",
+    "        print(f\"Number of classes: {len(dataset.ontology)}\")\n",
+    "    except Exception as e:\n",
+    "        print(f\"Failed to load COCO dataset: {e}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Fixes: #464 

- Replaced hardcoded local paths with placeholders:
- Added a guard that detects unchanged placeholders and prints a clear instruction message.
- Added path existence checks with user-friendly output when files are not found.

