### PR TITLE
fix: correct typo ImageDetecctionDataset in DetectionModel docstring

### DIFF
--- a/perceptionmetrics/models/detection.py
+++ b/perceptionmetrics/models/detection.py
@@ -57,7 +57,7 @@ class DetectionModel(PerceptionModel):
         """Perform evaluation for a detection dataset
 
         :param dataset: Detection dataset for which evaluation will be performed
-        :type dataset: ImageDetecctionDataset
+        :type dataset: ImageDetectionDataset
         :param split: Split(s) to use, defaults to "test"
         :type split: Union[str, List[str]]
         :param ontology_translation: JSON file containing translation between dataset and model output ontologies


### PR DESCRIPTION
## Summary

Fixes a typo in the docstring of `DetectionModel.eval()` in `perceptionmetrics/models/detection.py`.

Closes #475

## Change
```python
# Before (wrong)
:type dataset: ImageDetecctionDataset

# After (correct)
:type dataset: ImageDetectionDataset
```

## Files Changed

- `perceptionmetrics/models/detection.py`

Github: @vinitjain2005
