### PR TITLE
fix: save sample_pred per-sample instead of full batch pred in TF eval

### DIFF
--- a/perceptionmetrics/models/tf_segmentation.py
+++ b/perceptionmetrics/models/tf_segmentation.py
@@ -465,8 +465,8 @@ class TensorflowImageSegmentationModel(ImageSegmentationModel):
                         sample_df.to_csv(
                             os.path.join(predictions_outdir, f"{sample_idx}.csv")
                         )
-                    pred = Image.fromarray(np.squeeze(pred).astype(np.uint8))
-                    pred.save(os.path.join(predictions_outdir, f"{sample_idx}.png"))
+                    sample_img = Image.fromarray(np.squeeze(sample_pred).astype(np.uint8))
+                    sample_img.save(os.path.join(predictions_outdir, f"{sample_idx}.png"))
 
         return um.get_metrics_dataframe(metrics_factory, eval_ontology)
 


### PR DESCRIPTION
Closes #479

## Summary
Fixes a bug in `TensorflowImageSegmentationModel.eval()` where batch predictions were incorrectly saved per sample, causing `.png` outputs to contain the entire batch instead of individual predictions.

## Testing
Verified with a minimal reproduction script:
- Before fix: `(3, 2, 2)` (full batch)
- After fix: `(2, 2)` (per-sample)