### PR TITLE
fix: correct return type hint in build_dataset() functions

### DIFF
--- a/perceptionmetrics/datasets/coco.py
+++ b/perceptionmetrics/datasets/coco.py
@@ -11,7 +11,7 @@ def build_coco_dataset(
     image_dir: str,
     coco_obj: Optional[COCO] = None,
     split: str = "train",
-) -> Tuple[pd.DataFrame, dict]:
+) -> Tuple[pd.DataFrame, dict, str]:
     """Build dataset and ontology dictionaries from COCO dataset structure
 
     :param annotation_file: Path to the COCO-format JSON annotation file

--- a/perceptionmetrics/datasets/yolo.py
+++ b/perceptionmetrics/datasets/yolo.py
@@ -12,7 +12,7 @@ from perceptionmetrics.utils import io as uio
 
 def build_dataset(
     dataset_fname: str, dataset_dir: Optional[str] = None, im_ext: str = "jpg"
-) -> Tuple[pd.DataFrame, dict]:
+) -> Tuple[pd.DataFrame, dict, str]:
     """Build dataset and ontology dictionaries from YOLO dataset structure
 
     :param dataset_fname: Path to the YAML dataset configuration file


### PR DESCRIPTION
## Summary

Fixes incorrect return type hints in `build_dataset()` functions across two dataset files.

Closes #477

## Problem

Both `build_dataset()` functions declared `-> Tuple[pd.DataFrame, dict]` but actually return 3 values — `dataset`, `ontology`, and `dataset_dir`. This causes static analysis tools like `mypy` and `pyright` to flag type errors.

## Fix
```python
# Before (wrong)
) -> Tuple[pd.DataFrame, dict]:

# After (correct)
) -> Tuple[pd.DataFrame, dict, str]:
```

## Files Changed

- `perceptionmetrics/datasets/yolo.py`
- `perceptionmetrics/datasets/coco.py`

Github: @vinitjain2005
