### PR TITLE
docs: fix typo onotology to ontology in rellis3d.py docstring

### DIFF
--- a/perceptionmetrics/datasets/rellis3d.py
+++ b/perceptionmetrics/datasets/rellis3d.py
@@ -20,7 +20,7 @@ def build_dataset(
     :type split_dir: str
     :param ontology_fname: YAML file contained in the ontology compressed directory
     :type ontology_fname: str
-    :return: Dataset and onotology
+    :return: Dataset and ontology
     :rtype: Tuple[dict, dict]
     """
     # Check that provided paths exist and ensure they are absolute


### PR DESCRIPTION
## Summary

Fixes a typo in the docstring of `build_dataset()` in `perceptionmetrics/datasets/rellis3d.py`.

Closes #485

## Change
```python
# Before (wrong)
:return: Dataset and onotology

# After (correct)
:return: Dataset and ontology
```

## Files Changed

- `perceptionmetrics/datasets/rellis3d.py`

Github: @vinitjain2005
