### PR TITLE
fix: handle dict result from detection models in pm_batch

### DIFF
--- a/perceptionmetrics/cli/batch.py
+++ b/perceptionmetrics/cli/batch.py
@@ -160,7 +160,11 @@ def batch(command, jobs_cfg):
             print(f"Error processing job {job_id}: {e}")
             continue
 
-        # We assume that the command returns the results as a pandas DataFrame
+        # Handle both dict and DataFrame results
+        # Detection models return a dict with metrics_df and metrics_factory
+        if isinstance(result, dict):
+            result = result.get("metrics_df")
+
         result["job_id"] = job_id
         result = result.set_index("job_id", append=True)
 


### PR DESCRIPTION
## Summary

Fixes `pm_batch evaluate` crashing with `AttributeError` when running detection tasks.

Closes #487

## Problem

`TorchImageDetectionModel.eval()` returns a dictionary:
```python
return {
    "metrics_df": metrics_factory.get_metrics_dataframe(self.ontology),
    "metrics_factory": metrics_factory,
}
```

But `batch.py` assumed the result is always a DataFrame:
```python
# This crashes with AttributeError when result is a dict
result["job_id"] = job_id
result = result.set_index("job_id", append=True)
```

This causes:
```
AttributeError: 'dict' object has no attribute 'set_index'
```

## Fix

Added a check to extract `metrics_df` from dict results 
before processing:
```python
# Before
# We assume that the command returns the results as a pandas DataFrame
result["job_id"] = job_id
result = result.set_index("job_id", append=True)

# After
# Handle both dict and DataFrame results
# Detection models return a dict with metrics_df and metrics_factory
if isinstance(result, dict):
    result = result.get("metrics_df")

result["job_id"] = job_id
result = result.set_index("job_id", append=True)
```

## Files Changed

- `perceptionmetrics/cli/batch.py`

## Impact

Every user running `pm_batch evaluate` with detection tasks was hitting this crash. This fix ensures batch evaluation works correctly for both segmentation and detection tasks.

Github: @vinitjain2005
