### PR TITLE
Fix mean IoU integration to avoid DataFrame indexing issue

### DIFF
--- a/perceptionmetrics/utils/segmentation_metrics.py
+++ b/perceptionmetrics/utils/segmentation_metrics.py
@@ -23,7 +23,6 @@ class SegmentationMetricsFactory:
         "accuracy",
         "f1_score",
         "iou",
-        "mean_iou",
         "dice_score",
     ]
 


### PR DESCRIPTION
This PR fixes an issue with the integration of the mean IoU (mIoU) metric
in the segmentation metrics pipeline.

Previously, 'mean_iou' was included in 'METRIC_NAMES', but unlike other
metrics it returns a scalar value instead of per-class results. This caused
an indexing error when building the metrics DataFrame.

Changes:
- Removed 'mean_iou' from 'METRIC_NAMES' to prevent incorrect per-class indexing
- Kept 'get_mean_iou' method available for explicit use

This ensures compatibility with the existing metric factory interface and
prevents runtime errors when generating the metrics DataFrame.