### PR TITLE
docs: update installation steps for Poetry 2.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,28 @@ ERROR: Can not perform a '--user' install. User site-packages are not visible in
 ```
 
 
-Install dependencies and activate poetry environment (you can get out of the Poetry shell by running `exit`):
-```
+Install dependencies:
+```bash
 poetry install
-poetry shell
 ```
+
+
+Activate the environment: 
+
+Depending on your Poetry version, use one of the following (you can leave the environment by running deactivate or exit):
+
+   * For Poetry 2.0+:
+     ```bash
+     poetry env activate
+     ```
+   * For Poetry 1.x:
+     ```bash
+     poetry shell
+     ```
+
+   *Note: Alternatively, you can run any command directly without activating the environment by prefixing it with `poetry run` (e.g., `poetry run python main.py`).*
+
+
 ### Using venv
 Create your virtual environment:
 ```


### PR DESCRIPTION
### What was changed?
Updated the README.md to include installation and environment activation instructions for both Poetry 1.x and 2.0+. Added `poetry env activate` and clarified how to exit the environment using `deactivate` or `exit`.

### Why was it changed?
To ensure the documentation is compatible with Poetry 2.0+, as the previous instructions only covered `poetry shell`.

### How was it tested?
Verified in a development environment with Poetry 2.3.2, confirming the activation output and the environment exit behavior.

Closes #493