### PR TITLE
fix: remove inverted try/except in draw_detections and add empty-boxe…

### DIFF
--- a/perceptionmetrics/utils/image.py
+++ b/perceptionmetrics/utils/image.py
@@ -31,6 +31,9 @@ def draw_detections(
     """
     image = np.array(image)
 
+    if len(boxes) == 0:
+        return image
+
     # Create supervision detections
     detections = sv.Detections(xyxy=boxes, class_id=class_ids, confidence=scores)
 
@@ -47,27 +50,14 @@ def draw_detections(
         else:
             labels.append(name)
 
-    try:
-        # Try older style (BoxAnnotator handles labels)
-        try:
-            palette = sv.Color.DEFAULT
-        except AttributeError:
-            palette = sv.ColorPalette.default()
+    box_annotator = sv.BoxAnnotator()
+    ann_image = box_annotator.annotate(scene=image, detections=detections)
 
-        annotator = sv.BoxAnnotator(
-            color=palette, text_scale=0.7, text_thickness=1, text_padding=2
-        )
-        ann_image = annotator.annotate(
-            scene=image, detections=detections, labels=labels
-        )
-    except TypeError:
-        # Fallback for newer supervision (BoxAnnotator + LabelAnnotator)
-        box_annotator = sv.BoxAnnotator()
-        ann_image = box_annotator.annotate(scene=image, detections=detections)
-
-        label_annotator = sv.LabelAnnotator()
-        ann_image = label_annotator.annotate(
-            scene=ann_image, detections=detections, labels=labels
-        )
+    label_annotator = sv.LabelAnnotator(
+        text_scale=0.7, text_thickness=1, text_padding=2
+    )
+    ann_image = label_annotator.annotate(
+        scene=ann_image, detections=detections, labels=labels
+    )
 
     return ann_image

--- a/perceptionmetrics/utils/image.py
+++ b/perceptionmetrics/utils/image.py
@@ -14,7 +14,7 @@ def draw_detections(
 ) -> np.ndarray:
     """
     Draw bounding boxes and labels on the image using supervision.
-    Adapts to different supervision versions.
+    Requires supervision>=0.18 and uses BoxAnnotator + LabelAnnotator.
 
     :param image: PIL Image
     :type image: Image.Image
@@ -44,7 +44,6 @@ def draw_detections(
             name = class_names[i]
         else:
             name = str(class_ids[i])
-
         if scores is not None and i < len(scores):
             labels.append(f"{name}: {scores[i]:.2f}")
         else:


### PR DESCRIPTION
…s guard

The previous try/except pattern always attempted the old supervision API first, guaranteeing an exception on every call with supervision>=0.18. Replaced with a clean direct call using BoxAnnotator and LabelAnnotator. Also added an early return when boxes is empty to prevent a Detections validation crash on supervision 0.18.