### PR TITLE
fix: lazy load torch to prevent windows DLL crash on startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -234,8 +234,19 @@ with st.sidebar:
                     )
 
         # Load model action in sidebar
-        from perceptionmetrics.models.torch_detection import TorchImageDetectionModel
+        try:
+            from perceptionmetrics.models.torch_detection import TorchImageDetectionModel
+            _torch_available = True
+        except (ImportError, OSError):
+            _torch_available = False
         import json, tempfile
+
+        if not _torch_available:
+            st.warning(
+                "⚠️ PyTorch غير متاح على هذا النظام. "
+                "تبويب Inference لن يعمل. "
+                "يُرجى تثبيت PyTorch بشكل صحيح."
+            )
 
         load_model_btn = st.button(
             "Load Model",
@@ -243,6 +254,7 @@ with st.sidebar:
             width="stretch",
             help="Load and save the model for use in the Inference tab",
             key="sidebar_load_model_btn",
+            disabled=not _torch_available,
         )
 
         if load_model_btn:

--- a/perceptionmetrics/models/__init__.py
+++ b/perceptionmetrics/models/__init__.py
@@ -8,22 +8,22 @@ try:
 
     REGISTRY["torch_image_segmentation"] = TorchImageSegmentationModel
     REGISTRY["torch_lidar_segmentation"] = TorchLiDARSegmentationModel
-except ImportError:
+except (ImportError, OSError):
     print("Torch not available")
 
 try:
     from perceptionmetrics.models.torch_detection import TorchImageDetectionModel
 
     REGISTRY["torch_image_detection"] = TorchImageDetectionModel
-except ImportError:
+except (ImportError, OSError):
     print("Torch detection not available")
 
 try:
     from perceptionmetrics.models.tf_segmentation import TensorflowImageSegmentationModel
 
     REGISTRY["tensorflow_image_segmentation"] = TensorflowImageSegmentationModel
-except ImportError:
+except (ImportError, OSError):
     print("Tensorflow not available")
 
 if not REGISTRY:
-    raise Exception("No valid deep learning framework found")
+    raise ImportError("No valid deep learning framework found")

--- a/tabs/inference.py
+++ b/tabs/inference.py
@@ -3,7 +3,6 @@ from typing import Optional
 import streamlit as st
 import json
 from PIL import Image
-import torch
 
 
 def draw_detections(image: Image, predictions: dict, label_map: Optional[dict] = None):
@@ -18,6 +17,7 @@ def draw_detections(image: Image, predictions: dict, label_map: Optional[dict] =
     :return: np.ndarray with detections drawn (for st.image)
     :rtype: np.ndarray
     """
+    import torch
     from perceptionmetrics.utils import image as ui
 
     boxes = predictions.get("boxes", torch.empty(0)).cpu().numpy()
@@ -103,6 +103,7 @@ def inference_tab():
                     st.markdown("#### Detection Details")
 
                     # Convert predictions to JSON format
+                    import torch
                     detection_results = []
                     boxes = predictions.get("boxes", torch.empty(0)).cpu().numpy()
                     labels = predictions.get("labels", torch.empty(0)).cpu().numpy()


### PR DESCRIPTION
**Description:**
The Streamlit application currently crashes instantly on Windows machines that lack a fully configured CUDA/PyTorch environment due to an `OSError: [WinError 1114]` caused by a failed `c10.dll` initialization when importing PyTorch globally.

**Solution:**
- Implemented lazy-loading by moving `import torch` strictly inside the executing functions (e.g., in `tabs/inference.py`).
- Modified `models/__init__.py` to catch `OSError` (WinError 1114) alongside `ImportError`.
- Updated `app.py` to gracefully capture these exceptions and show a Streamlit warning instead of violently crashing the entire dashboard. Users can now access the Dataset Viewer and other tabs normally even if PyTorch is unsupported on their machine.
