### PR TITLE
Add BDD100K detection dataset loader

### DIFF
--- a/examples/bdd100k_detection.py
+++ b/examples/bdd100k_detection.py
@@ -1,0 +1,45 @@
+import argparse
+
+from perceptionmetrics.datasets.bdd100k import BDD100KDetectionDataset
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse user input arguments
+
+    :return: parsed arguments
+    :rtype: argparse.Namespace
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--images_dir",
+        type=str,
+        required=True,
+        help="Root directory containing train/ and val/ image folders",
+    )
+    parser.add_argument(
+        "--labels_dir",
+        type=str,
+        required=True,
+        help="Root directory containing train/ and val/ label JSON folders",
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    """Main function"""
+    args = parse_args()
+
+    dataset = BDD100KDetectionDataset(
+        images_dir=args.images_dir,
+        labels_dir=args.labels_dir,
+    )
+
+    print(f"Total samples: {len(dataset.dataset)}")
+    if not dataset.dataset.empty:
+        print(f"Splits: {dataset.dataset['split'].value_counts().to_dict()}")
+        print(f"Ontology classes: {list(dataset.ontology.keys())}")
+
+
+if __name__ == "__main__":
+    main()

--- a/perceptionmetrics/datasets/__init__.py
+++ b/perceptionmetrics/datasets/__init__.py
@@ -1,3 +1,7 @@
+from perceptionmetrics.datasets.bdd100k import (
+    BDD100KDetectionDataset,
+    build_bdd100k_dataset,
+)
 from perceptionmetrics.datasets.gaia import (
     GaiaImageSegmentationDataset,
     GaiaLiDARSegmentationDataset,
@@ -16,6 +20,7 @@ from perceptionmetrics.datasets.rellis3d import (
 )
 from perceptionmetrics.datasets.rugd import RUGDImageSegmentationDataset
 from perceptionmetrics.datasets.wildscenes import WildscenesImageSegmentationDataset
+
 try:
     from perceptionmetrics.datasets.coco import CocoDataset
 except ImportError:
@@ -23,6 +28,7 @@ except ImportError:
     CocoDataset = None
 
 REGISTRY = {
+    "bdd100k_image_detection": BDD100KDetectionDataset,
     "gaia_image_segmentation": GaiaImageSegmentationDataset,
     "gaia_lidar_segmentation": GaiaLiDARSegmentationDataset,
     "generic_image_segmentation": GenericImageSegmentationDataset,

--- a/perceptionmetrics/datasets/bdd100k.py
+++ b/perceptionmetrics/datasets/bdd100k.py
@@ -1,0 +1,140 @@
+from glob import glob
+import json
+import logging
+import os
+from typing import Tuple, List
+
+import pandas as pd
+
+from perceptionmetrics.datasets.detection import ImageDetectionDataset
+
+# BDD100K fixed 10-category ontology
+BDD100K_ONTOLOGY = {
+    "car": {"idx": 0, "rgb": [0, 0, 0]},
+    "truck": {"idx": 1, "rgb": [0, 0, 0]},
+    "bus": {"idx": 2, "rgb": [0, 0, 0]},
+    "person": {"idx": 3, "rgb": [0, 0, 0]},
+    "rider": {"idx": 4, "rgb": [0, 0, 0]},
+    "bike": {"idx": 5, "rgb": [0, 0, 0]},
+    "motor": {"idx": 6, "rgb": [0, 0, 0]},
+    "traffic light": {"idx": 7, "rgb": [0, 0, 0]},
+    "traffic sign": {"idx": 8, "rgb": [0, 0, 0]},
+    "train": {"idx": 9, "rgb": [0, 0, 0]},
+}
+
+
+def build_bdd100k_dataset(
+    images_dir: str, labels_dir: str
+) -> Tuple[pd.DataFrame, dict]:
+    """Build dataset DataFrame and ontology from BDD100K directory structure.
+
+    Expected layout::
+
+        <images_dir>/train/<filename>.jpg
+        <images_dir>/val/<filename>.jpg
+        <labels_dir>/train/<filename>.json
+        <labels_dir>/val/<filename>.json
+
+    :param images_dir: Root directory containing train/ and val/ image folders
+    :type images_dir: str
+    :param labels_dir: Root directory containing train/ and val/ label folders
+    :type labels_dir: str
+    :return: Tuple of (dataset DataFrame with columns [image, annotation, split],
+             ontology dict)
+    :rtype: Tuple[pd.DataFrame, dict]
+    """
+    ontology = dict(BDD100K_ONTOLOGY)
+
+    rows = []
+    for split in ["train", "val"]:
+        split_images_dir = os.path.join(images_dir, split)
+        if not os.path.isdir(split_images_dir):
+            logging.warning(
+                "Image split directory not found: %s; skipping.", split_images_dir
+            )
+            continue
+
+        image_files = glob(os.path.join(split_images_dir, "*.jpg")) + glob(
+            os.path.join(split_images_dir, "*.png")
+        )
+        for image_fname in sorted(image_files):
+            image_basename = os.path.basename(image_fname)
+            stem = os.path.splitext(image_basename)[0]
+            label_fname = os.path.join(labels_dir, split, f"{stem}.json")
+
+            if not os.path.isfile(label_fname):
+                logging.warning(
+                    "No matching label file for image '%s'; skipping.",
+                    image_fname,
+                )
+                continue
+
+            rows.append(
+                {
+                    "image": image_fname,
+                    "annotation": label_fname,
+                    "split": split,
+                }
+            )
+
+    dataset = pd.DataFrame(rows)
+    dataset.attrs = {"ontology": ontology}
+
+    return dataset, ontology
+
+
+class BDD100KDetectionDataset(ImageDetectionDataset):
+    """BDD100K object detection dataset.
+
+    :param images_dir: Root directory containing train/ and val/ image folders
+    :type images_dir: str
+    :param labels_dir: Root directory containing train/ and val/ label folders
+    :type labels_dir: str
+    """
+
+    def __init__(self, images_dir: str, labels_dir: str):
+        dataset, ontology = build_bdd100k_dataset(images_dir, labels_dir)
+        # Paths in the DataFrame are already absolute; dataset_dir is used
+        # only by PerceptionDataset base class (must not be None).
+        super().__init__(dataset=dataset, dataset_dir=images_dir, ontology=ontology)
+
+    def read_annotation(self, fname: str) -> Tuple[List[List[float]], List[int]]:
+        """Read bounding boxes and category indices from a BDD100K per-image JSON.
+
+        Objects without a ``box2d`` key (e.g. lane/poly2d annotations) are
+        skipped.  Unknown categories not in the BDD100K ontology are skipped
+        with a warning.
+
+        :param fname: Path to the per-image JSON annotation file
+        :type fname: str
+        :return: Tuple of (boxes as [[x1, y1, x2, y2], ...], category_indices)
+        :rtype: Tuple[List[List[float]], List[int]]
+        """
+        with open(fname, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        # Build reverse lookup: category name -> index
+        cat_to_idx = {name: info["idx"] for name, info in self.ontology.items()}
+
+        boxes = []
+        category_indices = []
+
+        objects = data.get("frames", [{}])[0].get("objects", [])
+        for obj in objects:
+            if "box2d" not in obj:
+                continue
+
+            category = obj.get("category", "")
+            if category not in cat_to_idx:
+                logging.warning(
+                    "Unknown category '%s' in annotation '%s'; skipping.",
+                    category,
+                    fname,
+                )
+                continue
+
+            box = obj["box2d"]
+            boxes.append([box["x1"], box["y1"], box["x2"], box["y2"]])
+            category_indices.append(cat_to_idx[category])
+
+        return boxes, category_indices

--- a/tests/test_bdd100k.py
+++ b/tests/test_bdd100k.py
@@ -1,0 +1,235 @@
+import json
+import logging
+import sys
+from unittest.mock import MagicMock, mock_open, patch
+
+import pandas as pd
+
+# Stub out heavy optional C-extensions that are not available in the test
+# environment (open3d, supervision, etc.) before importing any perceptionmetrics module.
+for _stub in ("open3d", "supervision"):
+    if _stub not in sys.modules:
+        sys.modules[_stub] = MagicMock()
+
+# Ensure tqdm.tqdm is a callable no-op (used in detection.py)
+if "tqdm" not in sys.modules:
+    import tqdm
+_tqdm_mod = sys.modules["tqdm"]
+if not callable(getattr(_tqdm_mod, "tqdm", None)):
+    _tqdm_mod.tqdm = lambda iterable, **kw: iterable  # type: ignore[attr-defined]
+
+from perceptionmetrics.datasets.bdd100k import (  # noqa: E402
+    BDD100KDetectionDataset,
+    build_bdd100k_dataset,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_ANNOTATION_VALID = {
+    "name": "img1.jpg",
+    "frames": [
+        {
+            "objects": [
+                {
+                    "category": "car",
+                    "box2d": {"x1": 10, "y1": 20, "x2": 100, "y2": 80},
+                },
+                {
+                    "category": "person",
+                    "box2d": {"x1": 50, "y1": 60, "x2": 150, "y2": 200},
+                },
+            ]
+        }
+    ],
+}
+
+_FAKE_ANNOTATION_NO_BOX2D = {
+    "name": "img2.jpg",
+    "frames": [
+        {
+            "objects": [
+                {
+                    "category": "car",
+                    "box2d": {"x1": 10, "y1": 20, "x2": 100, "y2": 80},
+                },
+                {
+                    "category": "lane",
+                    "poly2d": [{"vertices": [[0, 0], [1, 1]]}],
+                },
+            ]
+        }
+    ],
+}
+
+_FAKE_ANNOTATION_UNKNOWN_CATEGORY = {
+    "name": "img3.jpg",
+    "frames": [
+        {
+            "objects": [
+                {
+                    "category": "car",
+                    "box2d": {"x1": 5, "y1": 10, "x2": 50, "y2": 40},
+                },
+                {
+                    "category": "helicopter",
+                    "box2d": {"x1": 0, "y1": 0, "x2": 1, "y2": 1},
+                },
+            ]
+        }
+    ],
+}
+
+
+def _make_patched_dataset(annotation):
+    """Return a BDD100KDetectionDataset with filesystem calls mocked.
+
+    The dataset is created with empty glob results (no images discovered),
+    and ``read_annotation`` is invoked with the given annotation dict mocked
+    into ``builtins.open`` / ``json.load``.
+
+    :param annotation: Dictionary simulating a BDD100K per-image JSON
+    :type annotation: dict
+    :return: Tuple of (dataset instance, boxes, category_indices)
+    :rtype: tuple
+    """
+
+    def _fake_glob(pattern):
+        return []
+
+    with patch(
+        "perceptionmetrics.datasets.bdd100k.glob", side_effect=_fake_glob
+    ), patch("os.path.isdir", return_value=True):
+        ds = BDD100KDetectionDataset("/images", "/labels")
+
+    with patch("builtins.open", mock_open(read_data=json.dumps(annotation))), patch(
+        "json.load", return_value=annotation
+    ):
+        boxes, cat_indices = ds.read_annotation("/labels/train/fake.json")
+
+    return ds, boxes, cat_indices
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_bdd100k_dataset():
+    """Verify build_bdd100k_dataset pairs train/val images with label paths.
+
+    Checks that the returned DataFrame has the correct columns, rows, and
+    split values for discovered images that have matching label files.
+    """
+
+    def _fake_glob(pattern):
+        if "train" in pattern and pattern.endswith("*.jpg"):
+            return ["/images/train/img1.jpg", "/images/train/img2.jpg"]
+        if "val" in pattern and pattern.endswith("*.jpg"):
+            return ["/images/val/img3.jpg"]
+        return []
+
+    with patch(
+        "perceptionmetrics.datasets.bdd100k.glob", side_effect=_fake_glob
+    ), patch("os.path.isdir", return_value=True), patch(
+        "os.path.isfile", return_value=True
+    ):
+        dataset, ontology = build_bdd100k_dataset("/images", "/labels")
+
+    assert isinstance(dataset, pd.DataFrame)
+    assert list(dataset.columns) == ["image", "annotation", "split"]
+    assert len(dataset) == 3
+    assert set(dataset["split"].unique()) == {"train", "val"}
+
+    # --- ontology must contain all 10 BDD100K classes ---
+    assert len(ontology) == 10
+    assert ontology["car"]["idx"] == 0
+    assert ontology["train"]["idx"] == 9
+
+
+def test_missing_label_skipped(caplog):
+    """Images with no matching label file are skipped with a warning.
+
+    :param caplog: pytest log capture fixture
+    :type caplog: pytest.LogCaptureFixture
+    """
+
+    def _fake_glob(pattern):
+        if "train" in pattern and pattern.endswith("*.jpg"):
+            return ["/images/train/img1.jpg"]
+        return []
+
+    def _fake_isfile(path):
+        # Label file does not exist
+        if path.endswith(".json"):
+            return False
+        return True
+
+    with patch(
+        "perceptionmetrics.datasets.bdd100k.glob", side_effect=_fake_glob
+    ), patch("os.path.isdir", return_value=True), patch(
+        "os.path.isfile", side_effect=_fake_isfile
+    ):
+        with caplog.at_level(logging.WARNING, logger="root"):
+            dataset, _ = build_bdd100k_dataset("/images", "/labels")
+
+    assert len(dataset) == 0
+    warning_messages = [
+        r.message for r in caplog.records if r.levelno == logging.WARNING
+    ]
+    assert any("No matching label file" in msg for msg in warning_messages)
+
+
+def test_read_annotation_correct():
+    """read_annotation returns correct boxes and category indices for known categories."""
+    _, boxes, cat_indices = _make_patched_dataset(_FAKE_ANNOTATION_VALID)
+
+    assert len(boxes) == 2
+    assert boxes[0] == [10, 20, 100, 80]
+    assert boxes[1] == [50, 60, 150, 200]
+    assert cat_indices[0] == 0  # car
+    assert cat_indices[1] == 3  # person
+
+
+def test_read_annotation_skips_no_box2d():
+    """read_annotation skips objects that have no box2d key (e.g. poly2d)."""
+    _, boxes, cat_indices = _make_patched_dataset(_FAKE_ANNOTATION_NO_BOX2D)
+
+    # Only the car with box2d should be returned, lane with poly2d is skipped
+    assert len(boxes) == 1
+    assert boxes[0] == [10, 20, 100, 80]
+    assert cat_indices[0] == 0  # car
+
+
+def test_read_annotation_skips_unknown_category(caplog):
+    """read_annotation skips unknown categories and logs a warning.
+
+    :param caplog: pytest log capture fixture
+    :type caplog: pytest.LogCaptureFixture
+    """
+
+    def _fake_glob(pattern):
+        return []
+
+    with patch(
+        "perceptionmetrics.datasets.bdd100k.glob", side_effect=_fake_glob
+    ), patch("os.path.isdir", return_value=True):
+        ds = BDD100KDetectionDataset("/images", "/labels")
+
+    with patch(
+        "builtins.open",
+        mock_open(read_data=json.dumps(_FAKE_ANNOTATION_UNKNOWN_CATEGORY)),
+    ), patch("json.load", return_value=_FAKE_ANNOTATION_UNKNOWN_CATEGORY):
+        with caplog.at_level(logging.WARNING, logger="root"):
+            boxes, cat_indices = ds.read_annotation("/labels/train/img3.json")
+
+    # Only the car should be returned; helicopter is unknown
+    assert len(boxes) == 1
+    assert boxes[0] == [5, 10, 50, 40]
+    assert cat_indices[0] == 0  # car
+
+    warning_messages = [
+        r.message for r in caplog.records if r.levelno == logging.WARNING
+    ]
+    assert any("helicopter" in msg for msg in warning_messages)


### PR DESCRIPTION
Closes #515

Adds a BDD100K detection dataset loader, following the same pattern as the existing YOLO loader.

## Files changed
- `perceptionmetrics/datasets/bdd100k.py`: ` BDD100KDetectionDataset` class and `build_bdd100k_dataset()` function
- `perceptionmetrics/datasets/__init__.py`: registers BDD100K in the `REGISTRY`
- `tests/test_bdd100k.py`: 5 mocked tests, no dataset download needed to run them
- `examples/bdd100k_detection.py`: shows how to load the dataset

## Expected directory layout
```
<images_dir>/train/*.jpg
<images_dir>/val/*.jpg
<labels_dir>/train/*.json  (one JSON per image)
<labels_dir>/val/*.json
```

## Tested on real data
Loaded 80,000 samples (70k train, 10k val). Ground truth boxes shown below.
<img width="1280" height="720" alt="b1c66a42-6f7d68ca" src="https://github.com/user-attachments/assets/e020c45d-e05e-449e-99d9-c88a8488d209" />
<img width="1280" height="720" alt="b1c81faa-3df17267" src="https://github.com/user-attachments/assets/41845ed4-565a-4097-8d4e-680b1d518296" />
<img width="1280" height="720" alt="b1c81faa-c80764c5" src="https://github.com/user-attachments/assets/53e1ff84-f5d3-4506-aacb-8efce43984fc" />