### PR TITLE
fixes #560: add computational cost tab to GUI evaluator

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import streamlit as st
 from tabs.dataset_viewer import dataset_viewer_tab
 from tabs.inference import inference_tab
 from tabs.evaluator import evaluator_tab
+from tabs.computational_cost import computational_cost_tab
 from perceptionmetrics.utils.gui import browse_folder
 
 
@@ -15,6 +16,8 @@ PAGES = {
     "Dataset Viewer": dataset_viewer_tab,
     "Inference": inference_tab,
     "Evaluator": evaluator_tab,
+    "Computational Cost": computational_cost_tab,
+
 }
 
 # Initialize commonly used session state keys
@@ -379,7 +382,7 @@ with st.sidebar:
                             st.error(f"Failed to load model: {e}")
 
 # Main content area with horizontal tabs
-tab1, tab2, tab3 = st.tabs(["Dataset Viewer", "Inference", "Evaluator"])
+tab1, tab2, tab3, tab4 = st.tabs(["Dataset Viewer", "Inference", "Evaluator", "Computational Cost"])
 
 with tab1:
     dataset_viewer_tab()
@@ -387,3 +390,5 @@ with tab2:
     inference_tab()
 with tab3:
     evaluator_tab()
+with tab4:
+    computational_cost_tab()

--- a/tabs/computational_cost.py
+++ b/tabs/computational_cost.py
@@ -1,0 +1,104 @@
+"""Computational cost tab for the PerceptionMetrics GUI.
+
+Wraps ``TorchImageDetectionModel.get_computational_cost`` in a Streamlit
+tab so users can inspect parameter count, model size, and empirical
+inference latency for the currently loaded detection model.
+"""
+
+import streamlit as st
+
+
+def computational_cost_tab():
+    """Render the Computational Cost tab.
+
+    Requires a detection model in ``st.session_state.detection_model``.
+    Configures input size and timing parameters, triggers the cost
+    estimation on click, and renders the resulting metrics plus the
+    full DataFrame.
+    """
+
+    st.header("Computatioal Csot")
+
+
+    if not st.session_state.get("detetction_model_loaded",False):
+        st.warning(
+            "No detection model loaded. Use the sidebar to load a model first."
+        )
+        return
+    
+    model=st.session.state.detection_model()
+
+    st.subheader("Input Configuration")
+    col_h , col_w = st.columns(2)
+
+    with col_h:
+        height = st.number_input(
+            "Image Height", min_value=32, max_value=4096, value=640, step=32,
+        )
+    with col_w:
+        width = st.number_input(
+            "Image width", min_value=32, max_value=4096, value=640, step=32,
+            help="Dummy input width (pixels) passed to get_computational_cost.",
+        )
+
+        st.subheader("Timing Configuration")
+    col_runs, col_warmup = st.columns(2)
+
+    with col_runs:
+        runs = st.number_input(
+            "Timed runs", min_value=1, max_value=500, value=30, step=1,
+            help="Number of forward passes timed and averaged.",
+        )
+    with col_warmup:
+        warm_up_runs = st.number_input(
+            "Warm-up runs", min_value=0, max_value=100, value=5, step=1,
+            help="Forward passes before timing starts (stabilises GPU).",
+        )
+
+
+    if st.button("Run Cost Analysis", type= "primary"):
+        with st.spinner("Running forward passses - do not close this tab..."):
+            cost_df = model.get_computational_cost(
+                image_size = (int(height), int(width)),
+                runs = int(runs),
+                warm_up_runs = int(warm_up_runs)
+            )
+
+        st.session_state.computational_cost_result = cost_df
+
+    result_df = st.session_state.get("computational_cost_result")
+    if result_df is None : 
+        st.info("Configure inputs above and click **Run Cost Analysis**.")
+        return
+    
+    print(result_df.iloc[0].to_dict())
+
+    result = result_df.iloc[0].to_dict()
+
+    st.subheader("Result")
+    m1 ,m2 ,m3 , m4 = st.columns(4)
+    m1.metric("Input shape" , result["input_shape"])
+    m2.metric("Parameters", f"{result['n_params'] / 1e6:.2f} M")
+    m3.metric(
+        "Model size",
+        f"{result['size_mb']:.2f} MB" if result["size_mb"] is not None else "N/A",
+    )
+    m4.metric(
+        "Inference latency",
+        f"{result['inference_time_s']* 1000:.2f} ms",
+        help= f"Mean over {int(runs)} timed runs after {int(warm_up_runs)} warm-ups",
+    )
+
+    fps= 1.0 / result["inference_time_s"] if result["inference_time_s"] > 0 else 0.0
+    st.metric("Throughput", f"{fps:.1f} FPS")
+
+
+    with st.expander("Full raw Dataframe"):
+        st.dataframe(result_df, use_container_width=True)
+        st.download_button(
+            label= "Download as CSV",
+            data = result_df.to_csv(index=False).encode("utf-8"),
+            file_name= "computational_cost.csv",
+            mime="text/csv"
+        )
+    


### PR DESCRIPTION


## Summary

Fixes #560

Adds a **Computational Cost** tab to the Streamlit GUI that wraps `TorchImageDetectionModel.get_computational_cost()` for the currently loaded detection model. Closes the GUI ↔ CLI feature parity gap flagged in the discussion on #539.

Closes #XXX.

## Changes

- **New** `tabs/computational_cost.py` — standalone tab function following the `*_tab()` convention used by the other three tabs. No shared base (matches the existing codebase pattern).
- **Modified** `app.py` — three edits:
  1. Import `computational_cost_tab`
  2. Extend `st.tabs([...])` from 3 to 4 entries
  3. Extend the `PAGES` dict to stay in sync

## How it works

- Reuses the same sidebar-loaded model via `st.session_state.detection_model` (consistent with `evaluator_tab` and `inference_tab`).
- Gates the expensive `get_computational_cost()` call behind `st.button("Run Cost Analysis")` so widget interactions (number inputs) don't retrigger 30+ forward passes on every keystroke.
- Persists the resulting DataFrame in `st.session_state.computational_cost_result` so re-renders on widget changes reuse the cached result instead of recomputing.
- Renders metrics using the same unit conventions as `examples/torch_computational_cost.py` (`n_params / 1e6` for M, `inference_time_s * 1000` for ms) — no new formatting invented.
- Derived throughput (FPS = 1 / inference_time_s) added as an extra metric — not in the DataFrame, but useful for deployment decisions. Handles the zero-division edge case.
- CSV export via `st.download_button` mirrors the CLI's `results.to_csv(out_fname)` behavior.

## Testing

Manual, locally:
- [x] `streamlit run app.py` launches without errors.
- [x] All three pre-existing tabs still render correctly.
- [x] New tab shows a warning when no detection model is loaded.
- [x] After loading a torchvision detection model from the sidebar, the tab accepts custom image size + runs + warm-up and produces sensible numbers (params in M, size in MB, latency in ms, FPS derived correctly).
- [x] CSV download produces a file with the same 4-column schema the CLI produces.
- [x] Modifying the number inputs after a run does NOT retrigger the forward passes (button-gated, confirmed via terminal output).

## Out of scope

- No changes to `get_computational_cost()` itself. FLOPs / MACs reporting is proposed as a follow-up issue with a separate dependency discussion.
- No segmentation / LiDAR changes. The GUI currently supports detection only per the README; extending to other tasks is a follow-up when GUI support is extended.

