### PR TITLE
Fix #489: use public supervision API for annotation (works on 0.18-0.29)

### DIFF
--- a/perceptionmetrics/utils/image.py
+++ b/perceptionmetrics/utils/image.py
@@ -47,13 +47,9 @@ def draw_detections(
         else:
             labels.append(name)
 
+    palette = sv.ColorPalette.DEFAULT  # available in both old and new supervision
     try:
-        # Try older style (BoxAnnotator handles labels)
-        try:
-            palette = sv.Color.DEFAULT
-        except AttributeError:
-            palette = sv.ColorPalette.default()
-
+        # Older supervision (<= 0.21): one BoxAnnotator draws boxes AND labels
         annotator = sv.BoxAnnotator(
             color=palette, text_scale=0.7, text_thickness=1, text_padding=2
         )
@@ -61,11 +57,13 @@ def draw_detections(
             scene=image, detections=detections, labels=labels
         )
     except TypeError:
-        # Fallback for newer supervision (BoxAnnotator + LabelAnnotator)
-        box_annotator = sv.BoxAnnotator()
+        # Newer supervision (>= 0.22): boxes and labels are separate annotators
+        box_annotator = sv.BoxAnnotator(color=palette)
         ann_image = box_annotator.annotate(scene=image, detections=detections)
 
-        label_annotator = sv.LabelAnnotator()
+        label_annotator = sv.LabelAnnotator(
+            color=palette, text_scale=0.7, text_thickness=1, text_padding=2
+        )
         ann_image = label_annotator.annotate(
             scene=ann_image, detections=detections, labels=labels
         )

--- a/tabs/dataset_viewer.py
+++ b/tabs/dataset_viewer.py
@@ -11,9 +11,7 @@ def dataset_viewer_tab():
     from perceptionmetrics.datasets.yolo import YOLODataset
     import numpy as np
     from PIL import Image
-    from supervision.draw.color import ColorPalette
-    from supervision.detection.annotate import BoxAnnotator
-    from supervision.detection.core import Detections
+    from perceptionmetrics.utils.image import draw_detections
 
     # Get inputs from session state
     dataset_path = st.session_state.get("dataset_path", "")
@@ -288,16 +286,12 @@ def dataset_viewer_tab():
                 else:
                     class_names = [str(cat_id) for cat_id in category_indices]
 
-                # Annotate image
-                palette = ColorPalette.default()
-                detections = Detections(
-                    xyxy=np.array(boxes), class_id=np.array(category_indices)
-                )
-                annotator = BoxAnnotator(
-                    color=palette, text_scale=0.7, text_thickness=1, text_padding=2
-                )
-                annotated_img = annotator.annotate(
-                    scene=img_np, detections=detections, labels=class_names
+                # Annotate image using the shared, version-adaptive helper
+                annotated_img = draw_detections(
+                    image=img,
+                    boxes=np.array(boxes),
+                    class_ids=np.array(category_indices),
+                    class_names=class_names,
                 )
 
                 # Resize for display


### PR DESCRIPTION
Fixes #489.

**Problem.** `tabs/dataset_viewer.py` imported `BoxAnnotator` from the internal path `supervision.detection.annotate`, which was removed in supervision ≥ 0.22, causing `ModuleNotFoundError` for anyone whose environment resolves a supervision newer than the pinned 0.18.0. While investigating I also found that the shared `utils/image.py::draw_detections()` helper (used by `tabs/inference.py`) crashes on modern supervision because its palette fallback calls `sv.Color.DEFAULT` / `sv.ColorPalette.default()`, both of which raise `AttributeError` on recent versions (and are not caught by its `except TypeError`).

**Fix.**
- `utils/image.py`: use `sv.ColorPalette.DEFAULT` (available on old and new supervision) and keep the existing old-API/new-API `try/except`, so both `BoxAnnotator`-combined (≤0.21) and `BoxAnnotator` + `LabelAnnotator` (≥0.22) paths work.
- `tabs/dataset_viewer.py`: remove the broken inline annotation and delegate to `draw_detections()`, matching how `tabs/inference.py` already renders detections.

**Verification.** Tested end-to-end against **supervision 0.18.0 (current pin)** and **0.29.1 (latest)**; both render boxes/labels and return a valid `uint8` ndarray. No dependency changes required — confirmed `numpy 1.26.4` (project pin) coexists with modern supervision.