### PR TITLE
Fix #562: pass image tensor to resize_image() in TF segmentation t_in

### DIFF
--- a/perceptionmetrics/models/tf_segmentation.py
+++ b/perceptionmetrics/models/tf_segmentation.py
@@ -273,6 +273,7 @@ class TensorflowImageSegmentationModel(ImageSegmentationModel):
 
             if "resize" in self.model_cfg:
                 tensor = resize_image(
+                    tensor,
                     method="bilinear",
                     width=self.model_cfg["resize"].get("width", None),
                     height=self.model_cfg["resize"].get("height", None),


### PR DESCRIPTION
Fixes #562.

In `TfSemanticSegmentationModel`'s `t_in` input transform, `resize_image()` was called without its required first positional argument (`image`), raising `TypeError` whenever TF segmentation inference runs with `resize` enabled. This passes `tensor` (already produced by `tf.convert_to_tensor(image)` on the preceding line), consistent with the `resize_image(image, ...)` call at line ~191 and the `crop_center(tensor, ...)` call immediately below it.

`resize_image(` appears at only these two call sites in the codebase; this was the only affected one.