### PR TITLE
Fix/563 eval model dict csv

### DIFF
--- a/perceptionmetrics/cli/eval_model.py
+++ b/perceptionmetrics/cli/eval_model.py
@@ -1,3 +1,5 @@
+import os
+
 import click
 
 from perceptionmetrics import cli
@@ -206,7 +208,12 @@ def eval_model(
         predictions_outdir=predictions_outdir,
         results_per_sample=predictions_outdir is not None,
     )
-    results.to_csv(out_fname)
+
+    # Detection models return a dict with metrics_df and metrics_factory;
+    # other tasks return the metrics DataFrame directly.
+    metrics_df = results.get("metrics_df") if isinstance(results, dict) else results
+    os.makedirs(os.path.dirname(os.path.abspath(out_fname)), exist_ok=True)
+    metrics_df.to_csv(out_fname)
 
     return results
 

--- a/perceptionmetrics/models/tf_segmentation.py
+++ b/perceptionmetrics/models/tf_segmentation.py
@@ -273,6 +273,7 @@ class TensorflowImageSegmentationModel(ImageSegmentationModel):
 
             if "resize" in self.model_cfg:
                 tensor = resize_image(
+                    tensor,
                     method="bilinear",
                     width=self.model_cfg["resize"].get("width", None),
                     height=self.model_cfg["resize"].get("height", None),


### PR DESCRIPTION
Fixes #563.

**Problem.** `pm_evaluate ... --out_fname results.csv` crashes with `AttributeError: 'dict' object has no attribute 'to_csv'` for detection models. `model.eval()` returns a dict `{"metrics_df", "metrics_factory"}` for detection (`torch_detection.py`), while segmentation/other tasks return a `DataFrame`; `cli/eval_model.py` called `.to_csv()` directly on the result. (The issue referenced `cli/evaluate.py:197`, but the CLI has since been refactored into `eval_model.py` / `eval_preds.py`; the bug is now at `eval_model.py:209`.)

**Fix.** Extract the metrics DataFrame with `results.get("metrics_df") if isinstance(results, dict) else results` — the same pattern already used in `cli/batch.py` — before writing the CSV, and preserve the function's existing `return results` contract. Also added `os.makedirs(os.path.dirname(os.path.abspath(out_fname)), exist_ok=True)` to match `cli/eval_preds.py`, so `--out_fname` with a non-existent parent directory works.

**Scope.** `cli/eval_preds.py` uses a different path (`dataset.eval_preds()`, which returns a DataFrame) and already creates the directory, so it needs no change; `cli/batch.py` already handled the dict case.